### PR TITLE
Create macro for number-based fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,30 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+//! This crate contains a set of macros that can be used to generate strongly-typed fields for
+//! structs. The macros implement the [newtype] pattern, which allows the compiler to enforce type
+//! safety while still making it easy to convert the fields to and from their underlying
+//! representation.
+//!
+//! # Example
+//!
+//! ```rust
+//! use typed_fields::number;
+//!
+//! // Define a new type that is backed by an `i64`
+//! number!(UserId);
+//!
+//! // Create a new `UserId` from an `i64`
+//! let id = UserId::new(42);
+//!
+//! // Common traits like `Display` are automatically implemented for the type
+//! println!("User ID: {}", id);
+//! ```
+//!
+//! [newtype]: https://doc.rust-lang.org/rust-by-example/generics/new_types.html
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// Code in this library should never panic, which is why we are denying the use of both `expect` and
+// `unwrap`. Instead, functions must return a `Result` that can be handled by the caller.
+#![warn(clippy::expect_used)]
+#![warn(clippy::unwrap_used)]
+// All public items in this library must have documentation.
+#![warn(missing_docs)]
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+mod number;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,0 +1,95 @@
+/// Generate a new type for a number
+///
+/// The `number!` macro generates a new type that is backed by an `i64`. The new type implements
+/// common traits like `Display` and `From<i64>`. The inner value can be accessed using the `get`
+/// method.
+///
+/// # Example
+///
+/// ```
+/// use typed_fields::number;
+///
+/// // Define a new type that is backed by an `i64`
+/// number!(UserId);
+///
+/// // Create a new `UserId` from an `i64`
+/// let id = UserId::new(42);
+///
+/// // Common traits like `Display` are automatically implemented for the type
+/// println!("User ID: {}", id);
+/// ```
+#[macro_export]
+macro_rules! number {
+    (
+        $(#[$meta:meta])*
+        $id:ident
+    ) => {
+        $(#[$meta])*
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+        pub struct $id(i64);
+
+        impl $id {
+            pub fn new(id: i64) -> Self {
+                Self(id)
+            }
+
+            pub fn get(&self) -> i64 {
+                self.0
+            }
+        }
+
+        impl std::fmt::Display for $id {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<i64> for $id {
+            fn from(id: i64) -> $id {
+                $id(id)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    number!(TestId);
+
+    #[test]
+    fn get() {
+        let id = TestId::new(42);
+
+        assert_eq!(42, id.get());
+    }
+
+    #[test]
+    fn trait_display() {
+        let id = TestId::new(42);
+
+        assert_eq!("42", id.to_string());
+    }
+
+    #[test]
+    fn trait_from_i64() {
+        let _id: TestId = 42.into();
+    }
+
+    #[test]
+    fn trait_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<TestId>();
+    }
+
+    #[test]
+    fn trait_sync() {
+        fn assert_sync<T: Sync>() {}
+        assert_sync::<TestId>();
+    }
+
+    #[test]
+    fn trait_unpin() {
+        fn assert_unpin<T: Unpin>() {}
+        assert_unpin::<TestId>();
+    }
+}


### PR DESCRIPTION
A new macro has been created that generates a new type backed by a number. For this type, conversation traits to and from the inner type have been implemented. The type also implements `Display` to convert the value to a `String`.