### PR TITLE
Disable status checks for Codecov

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,9 @@
+---
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
We want to use Codecov to keep an eye on our test coverage, but we do not want it to fail CI when the test coverage drops too low. Especially in the beginning, when the test coverage can fluctuate quite a lot.