### PR TITLE
Rewrite functions as proc-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,45 @@
 version = 3
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "typed-fields"
 version = "0.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2021"
 # Setting the MSRV is only supported from 1.56.0 onwards.
 rust-version = "1.56"
 
+[lib]
+proc-macro = true
+
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+proc-macro2 = "1.0.60"
+quote = "1.0.25"
+syn = { version = "2.0.0", features = ["extra-traits"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,5 +27,57 @@
 // All public items in this library must have documentation.
 #![warn(missing_docs)]
 
+use proc_macro::TokenStream;
+
 mod name;
 mod number;
+
+/// Generate a new type for a string
+///
+/// The `name!` macro generates a new type that is backed by a `String`. The new type implements
+/// common traits like `Display` and `From<&str>` and `From<String>`. The inner value can be
+/// accessed using the `get` method.
+///
+/// # Example
+///
+/// ```
+/// use typed_fields::name;
+///
+/// // Define a new type that is backed by a `String`
+/// name!(Login);
+///
+/// // Create a new `UserId` from a `&str`
+/// let id = Login::new("jdno");
+///
+/// // Common traits like `Display` are automatically implemented for the type
+/// println!("Login: {}", id);
+/// ```
+#[proc_macro]
+pub fn name(input: TokenStream) -> TokenStream {
+    name::name_impl(input)
+}
+
+/// Generate a new type for a number
+///
+/// The `number!` macro generates a new type that is backed by an `i64`. The new type implements
+/// common traits like `Display` and `From<i64>`. The inner value can be accessed using the `get`
+/// method.
+///
+/// # Example
+///
+/// ```
+/// use typed_fields::number;
+///
+/// // Define a new type that is backed by an `i64`
+/// number!(UserId);
+///
+/// // Create a new `UserId` from an `i64`
+/// let id = UserId::new(42);
+///
+/// // Common traits like `Display` are automatically implemented for the type
+/// println!("User ID: {}", id);
+/// ```
+#[proc_macro]
+pub fn number(input: TokenStream) -> TokenStream {
+    number::number_impl(input)
+}

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,34 +1,17 @@
-/// Generate a new type for a number
-///
-/// The `number!` macro generates a new type that is backed by an `i64`. The new type implements
-/// common traits like `Display` and `From<i64>`. The inner value can be accessed using the `get`
-/// method.
-///
-/// # Example
-///
-/// ```
-/// use typed_fields::number;
-///
-/// // Define a new type that is backed by an `i64`
-/// number!(UserId);
-///
-/// // Create a new `UserId` from an `i64`
-/// let id = UserId::new(42);
-///
-/// // Common traits like `Display` are automatically implemented for the type
-/// println!("User ID: {}", id);
-/// ```
-#[macro_export]
-macro_rules! number {
-    (
-        $(#[$meta:meta])*
-        $id:ident
-    ) => {
-        $(#[$meta])*
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-        pub struct $id(i64);
+use proc_macro::TokenStream;
 
-        impl $id {
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse_macro_input;
+
+pub fn number_impl(input: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(input as Ident);
+
+    let newtype = quote! {
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+        pub struct #ident(i64);
+
+        impl #ident {
             pub fn new(id: i64) -> Self {
                 Self(id)
             }
@@ -38,58 +21,18 @@ macro_rules! number {
             }
         }
 
-        impl std::fmt::Display for $id {
+        impl std::fmt::Display for #ident {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(f, "{}", self.0)
             }
         }
 
-        impl From<i64> for $id {
-            fn from(id: i64) -> $id {
-                $id(id)
+        impl From<i64> for #ident {
+            fn from(id: i64) -> #ident {
+                #ident(id)
             }
         }
     };
-}
 
-#[cfg(test)]
-mod tests {
-    number!(TestId);
-
-    #[test]
-    fn get() {
-        let id = TestId::new(42);
-
-        assert_eq!(42, id.get());
-    }
-
-    #[test]
-    fn trait_display() {
-        let id = TestId::new(42);
-
-        assert_eq!("42", id.to_string());
-    }
-
-    #[test]
-    fn trait_from_i64() {
-        let _id: TestId = 42.into();
-    }
-
-    #[test]
-    fn trait_send() {
-        fn assert_send<T: Send>() {}
-        assert_send::<TestId>();
-    }
-
-    #[test]
-    fn trait_sync() {
-        fn assert_sync<T: Sync>() {}
-        assert_sync::<TestId>();
-    }
-
-    #[test]
-    fn trait_unpin() {
-        fn assert_unpin<T: Unpin>() {}
-        assert_unpin::<TestId>();
-    }
+    newtype.into()
 }

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -1,0 +1,45 @@
+use typed_fields::name;
+
+name!(TestName);
+
+#[test]
+fn get() {
+    let name = TestName::new("test");
+
+    assert_eq!("test", name.get());
+}
+
+#[test]
+fn trait_display() {
+    let name = TestName::new("test");
+
+    assert_eq!("test", name.to_string());
+}
+
+#[test]
+fn trait_from_string() {
+    let _name: TestName = String::from("test").into();
+}
+
+#[test]
+fn trait_from_str() {
+    let _name: TestName = "test".into();
+}
+
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestName>();
+}
+
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestName>();
+}
+
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestName>();
+}

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -1,0 +1,40 @@
+use typed_fields::number;
+
+number!(TestId);
+
+#[test]
+fn get() {
+    let id = TestId::new(42);
+
+    assert_eq!(42, id.get());
+}
+
+#[test]
+fn trait_display() {
+    let id = TestId::new(42);
+
+    assert_eq!("42", id.to_string());
+}
+
+#[test]
+fn trait_from_i64() {
+    let _id: TestId = 42.into();
+}
+
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestId>();
+}
+
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestId>();
+}
+
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestId>();
+}


### PR DESCRIPTION
The initial implementation of this crate used derive-macros. These were easy to write, but made it very difficult to instrument with features. For example, deriving serde's traits when a hypothetical `serde` feature is enabled was not possible to implement. Or, at least, I did not know how to do this ergonomically.

Switching to proc-macros increases the complexity and compile time of this crate, but it also gives us much more tools to control the macros' outputs. We expect that this will make it easier to implement complex types.