### PR TITLE
Create macro for fields with secrets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -133,7 +133,7 @@ jobs:
 
     strategy:
       matrix:
-        msrv: [1.56.1]
+        msrv: [1.60.0]
 
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
+name = "secrecy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +90,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "secrecy",
  "serde",
  "serde_json",
  "syn",
@@ -90,3 +101,9 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "zeroize"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ name = "typed-fields"
 version = "0.0.0"
 edition = "2021"
 
-# Setting the MSRV is only supported from 1.56.0 onwards.
-rust-version = "1.56"
+# We use the weak dependency feature to enable serde for optional dependencies.
+# https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features
+rust-version = "1.60"
 
 [lib]
 proc-macro = true
@@ -12,9 +13,16 @@ proc-macro = true
 # See more keys and their definitions at
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+serde = [
+    "dep:serde",
+    "secrecy?/serde"
+]
+
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1.0.25"
+secrecy = { version = "0.4.1", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 syn = { version = "2.0.0", features = ["extra-traits"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@ use proc_macro::TokenStream;
 
 mod name;
 mod number;
+#[cfg(feature = "secrecy")]
+mod secret;
 
 /// Generate a new type for a string
 ///
@@ -80,4 +82,29 @@ pub fn name(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn number(input: TokenStream) -> TokenStream {
     number::number_impl(input)
+}
+
+/// Generate a new type for a secret
+///
+/// The `secret!` macro generates a new type for secrets such as passwords and API tokens. The type
+/// uses the [`secrecy`](https://crates.io/crates/secrecy) crate internally to prevent accidentally
+/// leaking the inner value in debug or log statements.
+///
+/// The new type implements common traits like `Display` and `From<&str>` and `From<String>`. The
+/// inner value can be revealed using the `expose` method.
+///
+/// # Example
+///
+/// ```rust
+/// use typed_fields::secret;
+///
+/// secret!(ApiToken);
+///
+/// let token: ApiToken = "super-secret-api-token".into();
+/// let header = format!("Authorization: Bearer {}", token.expose());
+/// ```
+#[cfg(feature = "secrecy")]
+#[proc_macro]
+pub fn secret(input: TokenStream) -> TokenStream {
+    secret::secret_impl(input)
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,0 +1,68 @@
+use proc_macro::TokenStream;
+
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse_macro_input;
+
+pub fn secret_impl(input: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(input as Ident);
+    let derives = derives();
+
+    let newtype = quote! {
+        #derives
+        pub struct #ident(secrecy::SecretString);
+
+        impl #ident {
+            pub fn new(secret: &str) -> Self {
+                Self(secrecy::SecretString::new(String::from(secret)))
+            }
+
+            pub fn expose(&self) -> &str {
+                use secrecy::ExposeSecret;
+                self.0.expose_secret()
+            }
+        }
+
+        impl std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "[REDACTED]")
+            }
+        }
+
+        impl From<&str> for #ident {
+            fn from(secret: &str) -> #ident {
+                #ident(secrecy::SecretString::new(String::from(secret)))
+            }
+        }
+
+        impl From<String> for #ident {
+            fn from(secret: String) -> #ident {
+                #ident(secrecy::SecretString::new(secret))
+            }
+        }
+    };
+
+    newtype.into()
+}
+
+fn derives() -> proc_macro2::TokenStream {
+    let mut derives = quote! {
+        #[derive(Clone, Debug)]
+    };
+
+    derives.extend(derive_serde());
+
+    derives
+}
+
+#[cfg(feature = "serde")]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {
+        #[derive(serde::Deserialize)]
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {}
+}

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -1,0 +1,64 @@
+#[cfg(feature = "secrecy")]
+use typed_fields::secret;
+
+#[cfg(feature = "secrecy")]
+secret!(TestSecret);
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn expose() {
+    let secret = TestSecret::new("test");
+
+    assert_eq!("test", secret.expose());
+}
+
+#[cfg(all(feature = "secrecy", feature = "serde"))]
+#[test]
+fn trait_deserialize() {
+    let json = r#""test""#;
+
+    let config: TestSecret = serde_json::from_str(json).unwrap();
+
+    assert_eq!("test", config.expose());
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_display() {
+    let secret = TestSecret::new("test");
+
+    assert_eq!("[REDACTED]", secret.to_string());
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_from_str() {
+    let _secret: TestSecret = "test".into();
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_from_string() {
+    let _secret: TestSecret = "test".into();
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestSecret>();
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestSecret>();
+}
+
+#[cfg(feature = "secrecy")]
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestSecret>();
+}


### PR DESCRIPTION
A new macro has been created that generates a new type for fields that contain secrest such as passwords or API tokens. The field is backed by the `SecretString` type from the crate `secrecy`[^1], which prevents the contents of the string to be printed in logs or debug statements.

Since this feature requires a new dependency, it must be enabled with a feature flag.

[^1]: https://crates.io/crates/secrecy