### PR TITLE
Rename feature flag for secrets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ proc-macro = true
 # https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+secret = ["dep:secrecy"]
 serde = [
     "dep:serde",
     "secrecy?/serde"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ use proc_macro::TokenStream;
 
 mod name;
 mod number;
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 mod secret;
 
 /// Generate a new type for a string
@@ -103,7 +103,7 @@ pub fn number(input: TokenStream) -> TokenStream {
 /// let token: ApiToken = "super-secret-api-token".into();
 /// let header = format!("Authorization: Bearer {}", token.expose());
 /// ```
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[proc_macro]
 pub fn secret(input: TokenStream) -> TokenStream {
     secret::secret_impl(input)

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 use typed_fields::secret;
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 secret!(TestSecret);
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn expose() {
     let secret = TestSecret::new("test");
@@ -12,7 +12,7 @@ fn expose() {
     assert_eq!("test", secret.expose());
 }
 
-#[cfg(all(feature = "secrecy", feature = "serde"))]
+#[cfg(all(feature = "secret", feature = "serde"))]
 #[test]
 fn trait_deserialize() {
     let json = r#""test""#;
@@ -22,7 +22,7 @@ fn trait_deserialize() {
     assert_eq!("test", config.expose());
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_display() {
     let secret = TestSecret::new("test");
@@ -30,33 +30,33 @@ fn trait_display() {
     assert_eq!("[REDACTED]", secret.to_string());
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_from_str() {
     let _secret: TestSecret = "test".into();
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_from_string() {
     let _secret: TestSecret = "test".into();
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_send() {
     fn assert_send<T: Send>() {}
     assert_send::<TestSecret>();
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<TestSecret>();
 }
 
-#[cfg(feature = "secrecy")]
+#[cfg(feature = "secret")]
 #[test]
 fn trait_unpin() {
     fn assert_unpin<T: Unpin>() {}


### PR DESCRIPTION
The feature flag for the `secret!` macro has been renamed. This both makes it easier for the user to enable the feature and hides the implementation details.