### PR TITLE
Create macro for fields with a URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,35 @@
 version = 3
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "proc-macro2"
@@ -85,6 +110,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typed-fields"
 version = "0.1.0"
 dependencies = [
@@ -94,13 +134,41 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+ "url",
 ]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ proc-macro = true
 secret = ["dep:secrecy"]
 serde = [
     "dep:serde",
-    "secrecy?/serde"
+    "secrecy?/serde",
+    "url?/serde",
 ]
+url = ["dep:url"]
 
 [dependencies]
 proc-macro2 = "1.0.60"
@@ -30,6 +32,7 @@ quote = "1.0.25"
 secrecy = { version = "0.4.1", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 syn = { version = "2.0.0", features = ["extra-traits"] }
+url = { version = "2.2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ mod name;
 mod number;
 #[cfg(feature = "secret")]
 mod secret;
+#[cfg(feature = "url")]
+mod url;
 
 /// Generate a new type for a string
 ///
@@ -107,4 +109,31 @@ pub fn number(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn secret(input: TokenStream) -> TokenStream {
     secret::secret_impl(input)
+}
+
+/// Generate a new type for a URL
+///
+/// The `url!` macro generates a new type that is backed by a `Url` from the [`url`] crate. The new
+/// type implements common traits like `Display` and `TryFrom<&str>` and `TryFrom<String>`. The
+/// inner value can be accessed using the `get` method.
+///
+/// # Example
+///
+/// ```rust
+/// use typed_fields::url;
+///
+/// url!(BackendUrl);
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let url: BackendUrl = "https://api.example.com".try_into()?;
+///     # Ok(())
+///     // Do something with the URL...
+/// }
+/// ```
+///
+/// [`url`]: https://crates.io/crates/url
+#[cfg(feature = "url")]
+#[proc_macro]
+pub fn url(input: TokenStream) -> TokenStream {
+    url::url_impl(input)
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,0 +1,77 @@
+use proc_macro::TokenStream;
+
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse_macro_input;
+
+pub fn url_impl(input: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(input as Ident);
+    let derives = derives();
+
+    let newtype = quote! {
+        #derives
+        pub struct #ident(url::Url);
+
+         impl #ident {
+            pub fn new(url: url::Url) -> Self {
+                Self(url)
+            }
+
+            pub fn get(&self) -> &url::Url {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<url::Url> for #ident {
+            fn from(url: url::Url) -> Self {
+                Self(url)
+            }
+        }
+
+        impl TryFrom<&str> for #ident {
+            type Error = url::ParseError;
+
+            fn try_from(string: &str) -> Result<Self, Self::Error> {
+                Ok(Self(url::Url::try_from(string)?))
+            }
+        }
+
+        impl TryFrom<String> for #ident {
+            type Error = url::ParseError;
+
+            fn try_from(string: String) -> Result<Self, Self::Error> {
+                Self::try_from(string.as_str())
+            }
+        }
+    };
+
+    newtype.into()
+}
+
+fn derives() -> proc_macro2::TokenStream {
+    let mut derives = quote! {
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    };
+
+    derives.extend(derive_serde());
+
+    derives
+}
+
+#[cfg(feature = "serde")]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {
+        #[derive(serde::Deserialize, serde::Serialize)]
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {}
+}

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,0 +1,100 @@
+#[cfg(feature = "url")]
+use std::convert::TryInto;
+
+#[cfg(feature = "url")]
+use url::Url;
+
+#[cfg(feature = "url")]
+use typed_fields::url;
+
+#[cfg(feature = "url")]
+url!(TestUrl);
+
+#[cfg(feature = "url")]
+#[test]
+fn get() {
+    let input = Url::parse("postgres://localhost:5432/postgres").unwrap();
+
+    let url = TestUrl::new(input.clone());
+
+    assert_eq!(&input, url.get());
+}
+
+#[cfg(all(feature = "serde", feature = "url"))]
+#[test]
+fn trait_deserialize() {
+    let json = r#""postgres://localhost:5432/postgres""#;
+
+    let url: TestUrl = serde_json::from_str(json).unwrap();
+
+    assert_eq!("postgres://localhost:5432/postgres", url.to_string());
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_display() {
+    let url = TestUrl::new(Url::parse("https://example.com").unwrap());
+
+    assert_eq!("https://example.com/", url.to_string());
+}
+
+#[cfg(all(feature = "serde", feature = "url"))]
+#[test]
+fn trait_serialize() {
+    let url = TestUrl::new(Url::parse("https://example.com").unwrap());
+
+    let json = serde_json::to_string(&url).unwrap();
+
+    assert_eq!(r#""https://example.com/""#, json);
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_try_from_str() {
+    let _url: TestUrl = "https://example.com/".try_into().unwrap();
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_try_from_str_with_random_string() {
+    let url = TestUrl::try_from("test");
+
+    assert!(url.is_err());
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_try_from_string() {
+    let _url: TestUrl = String::from("postgres://user:password@locahost:5432/postgres")
+        .try_into()
+        .unwrap();
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_try_from_string_with_random_string() {
+    let url = TestUrl::try_from(String::from("test"));
+
+    assert!(url.is_err());
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUrl>();
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUrl>();
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUrl>();
+}


### PR DESCRIPTION
A new macro has been created that generates a new type that is backed by a `Url` from the `url`[^1] crate.

Since this feature requires a new dependency, it must be enabled with a feature flag.

[^1]: https://crates.io/crates/url