### PR TITLE
Build documentation for all features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.60"
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at
-# https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 secret = ["dep:secrecy"]


### PR DESCRIPTION
Builds on docs.rs can be customized using metadata in `Cargo.toml`. For this crate, we want to enable all features so that all macros show up on docs.rs.