### PR TITLE
Create macro for fields with a UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,19 +25,44 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
+ "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+dependencies = [
+ "num-traits 0.2.17",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -35,27 +72,21 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "secrecy"
@@ -69,40 +100,52 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "1217f97ab8e8904b57dd22eb61cde455fa7446a9c1cf43966066da047c1f3702"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.112"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
+checksum = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
 dependencies = [
+ "dtoa",
  "itoa",
- "ryu",
+ "num-traits 0.1.43",
  "serde",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -133,8 +176,9 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.0",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -160,13 +204,23 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
  "form_urlencoded",
  "idna",
+ "matches",
  "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ serde = [
     "dep:serde",
     "secrecy?/serde",
     "url?/serde",
+    "uuid?/serde",
 ]
 url = ["dep:url"]
+uuid = ["dep:uuid"]
 
 [dependencies]
 proc-macro2 = "1.0.60"
@@ -33,6 +35,7 @@ secrecy = { version = "0.4.1", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 syn = { version = "2.0.0", features = ["extra-traits"] }
 url = { version = "2.2.0", optional = true }
+uuid = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Do you like strongly-typed structs?
 - `number!` - a number-based type
 - `secret!` - a type for secrets (requires the `secret` feature)
 - `url!` - a type for URLs (requires the `url` feature)
+- `uuid!` - a type for UUIDs (requires the `uuid` feature)
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ mod number;
 mod secret;
 #[cfg(feature = "url")]
 mod url;
+#[cfg(feature = "uuid")]
+mod uuid;
 
 /// Generate a new type for a string
 ///
@@ -136,4 +138,31 @@ pub fn secret(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn url(input: TokenStream) -> TokenStream {
     url::url_impl(input)
+}
+
+/// Generate a new type for a UUID
+///
+/// The `uuid!` macro generates a new type that is backed by a `Uuid` from the [`uuid`] crate. The
+/// new type implements common traits like `Display` and `TryFrom<&str>` and `TryFrom<String>`. The
+/// inner value can be accessed using the `get` method.
+///
+/// # Example
+///
+/// ```rust
+/// use typed_fields::uuid;
+///
+/// uuid!(UserId);
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let id: UserId = "67e55044-10b1-426f-9247-bb680e5fe0c8".try_into()?;
+///     # Ok(())
+///     // Do something with the URL...
+/// }
+/// ```
+///
+/// [`uuid`]: https://crates.io/crates/uuid
+#[cfg(feature = "uuid")]
+#[proc_macro]
+pub fn uuid(input: TokenStream) -> TokenStream {
+    uuid::uuid_impl(input)
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,0 +1,77 @@
+use proc_macro::TokenStream;
+
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse_macro_input;
+
+pub fn uuid_impl(input: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(input as Ident);
+    let derives = derives();
+
+    let newtype = quote! {
+        #derives
+        pub struct #ident(uuid::Uuid);
+
+         impl #ident {
+            pub fn new(uuid: uuid::Uuid) -> Self {
+                Self(uuid)
+            }
+
+            pub fn get(&self) -> &uuid::Uuid {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<uuid::Uuid> for #ident {
+            fn from(uuid: uuid::Uuid) -> Self {
+                Self(uuid)
+            }
+        }
+
+        impl TryFrom<&str> for #ident {
+            type Error = uuid::Error;
+
+            fn try_from(string: &str) -> Result<Self, Self::Error> {
+                Ok(Self(uuid::Uuid::try_from(string)?))
+            }
+        }
+
+        impl TryFrom<String> for #ident {
+            type Error = uuid::Error;
+
+            fn try_from(string: String) -> Result<Self, Self::Error> {
+                Self::try_from(string.as_str())
+            }
+        }
+    };
+
+    newtype.into()
+}
+
+fn derives() -> proc_macro2::TokenStream {
+    let mut derives = quote! {
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    };
+
+    derives.extend(derive_serde());
+
+    derives
+}
+
+#[cfg(feature = "serde")]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {
+        #[derive(serde::Deserialize, serde::Serialize)]
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {}
+}

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -1,0 +1,99 @@
+#[cfg(feature = "uuid")]
+use std::convert::TryInto;
+
+#[cfg(feature = "uuid")]
+use typed_fields::uuid;
+#[cfg(feature = "uuid")]
+use uuid::uuid as uuid_v4;
+
+#[cfg(feature = "uuid")]
+uuid!(TestUuid);
+
+#[cfg(feature = "uuid")]
+#[test]
+fn get() {
+    let input = uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8");
+
+    let uuid = TestUuid::new(input);
+
+    assert_eq!(input, *uuid.get());
+}
+
+#[cfg(all(feature = "serde", feature = "uuid"))]
+#[test]
+fn trait_deserialize() {
+    let json = r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#;
+
+    let uuid: TestUuid = serde_json::from_str(json).unwrap();
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_display() {
+    let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+}
+
+#[cfg(all(feature = "serde", feature = "uuid"))]
+#[test]
+fn trait_serialize() {
+    let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
+
+    let json = serde_json::to_string(&uuid).unwrap();
+
+    assert_eq!(r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#, json);
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_try_from_str() {
+    let _uuid: TestUuid = "67e55044-10b1-426f-9247-bb680e5fe0c8".try_into().unwrap();
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_try_from_str_with_random_string() {
+    let uuid = TestUuid::try_from("test");
+
+    assert!(uuid.is_err());
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_try_from_string() {
+    let _uuid: TestUuid = String::from("67e55044-10b1-426f-9247-bb680e5fe0c8")
+        .try_into()
+        .unwrap();
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_try_from_string_with_random_string() {
+    let uuid = TestUuid::try_from(String::from("test"));
+
+    assert!(uuid.is_err());
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUuid>();
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUuid>();
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUuid>();
+}


### PR DESCRIPTION
A new macro has been created that generates a new type that is backed by a `Uuid` from the `uuid`[^1] crate.

[^1]: https://crates.io/crates/uuid