### PR TITLE
Fix broken builds due to error in uuid! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
A recent version of Rust broke the `uuid!` macro in the uuid[^1] crate. Since the typed-field crate theoretically compiles fine with version 1.0.0 of the uuid crate, we are only bumping the version in the lock file. This should ensure that the build problems are fixed in local development, while still providing the widest range of supported versions to users.

[^1]: https://crates.io/crates/uuid