### PR TITLE
Don't let Codecov fail CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -207,6 +207,7 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
When the Codecov action fails, which happens sometimes, it should not break CI as a whole.