### PR TITLE
Create macro for fields with a ULID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +39,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -39,6 +70,27 @@ name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+
+[[package]]
+name = "log"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matches"
@@ -65,27 +117,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.60"
+name = "ppv-lite86"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -143,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.0"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff13bb1732bccfe3b246f3fdb09edfd51c01d6f5299b7ccd9457c2e4e37774"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -176,9 +273,22 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "syn 2.0.0",
+ "syn 2.0.75",
+ "ulid",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ulid"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
+dependencies = [
+ "getrandom",
+ "rand",
+ "serde",
+ "web-time",
 ]
 
 [[package]]
@@ -222,6 +332,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ secret = ["dep:secrecy"]
 serde = [
     "dep:serde",
     "secrecy?/serde",
+    "ulid?/serde",
     "url?/serde",
     "uuid?/serde",
 ]
+ulid = ["dep:ulid"]
 url = ["dep:url"]
 uuid = ["dep:uuid"]
 
@@ -34,6 +36,7 @@ quote = "1.0.25"
 secrecy = { version = "0.4.1", optional = true }
 serde = { version = "1.0.103", features = ["derive"], optional = true }
 syn = { version = "2.0.0", features = ["extra-traits"] }
+ulid = { version = "1.1.3", optional = true }
 url = { version = "2.2.0", optional = true }
 uuid = { version = "1.0.0", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Do you like strongly-typed structs?
 - `name!` - a string-based type
 - `number!` - a number-based type
 - `secret!` - a type for secrets (requires the `secret` feature)
+- `ulid!` - a type for ULIDs (requires the `ulid` feature)
 - `url!` - a type for URLs (requires the `url` feature)
 - `uuid!` - a type for UUIDs (requires the `uuid` feature)
 
@@ -35,8 +36,10 @@ fn main() {
 
 Licensed under either of
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE)
+  or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT)
+  or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ mod name;
 mod number;
 #[cfg(feature = "secret")]
 mod secret;
+#[cfg(feature = "ulid")]
+mod ulid;
 #[cfg(feature = "url")]
 mod url;
 #[cfg(feature = "uuid")]
@@ -111,6 +113,33 @@ pub fn number(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn secret(input: TokenStream) -> TokenStream {
     secret::secret_impl(input)
+}
+
+/// Generate a new type for a ULID
+///
+/// The `ulid!` macro generates a new type that is backed by a `Ulid` from the [`ulid`] crate. The
+/// new type implements common traits like `Display` and `From<&str>` and `From<String>`. The inner
+/// value can be accessed using the `get` method.
+///
+/// # Example
+///
+/// ```rust
+/// use typed_fields::ulid;
+///
+/// ulid!(UserId);
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let id: UserId = "01ARZ3NDEKTSV4RRFFQ69G5FAV".try_into()?;
+///     # Ok(())
+///     // Do something with the URL...
+/// }
+/// ```
+///
+/// [`ulid`]: https://crates.io/crates/ulid
+#[cfg(feature = "ulid")]
+#[proc_macro]
+pub fn ulid(input: TokenStream) -> TokenStream {
+    ulid::ulid_impl(input)
 }
 
 /// Generate a new type for a URL

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -1,0 +1,77 @@
+use proc_macro::TokenStream;
+
+use proc_macro2::Ident;
+use quote::quote;
+use syn::parse_macro_input;
+
+pub fn ulid_impl(input: TokenStream) -> TokenStream {
+    let ident = parse_macro_input!(input as Ident);
+    let derives = derives();
+
+    let newtype = quote! {
+        #derives
+        pub struct #ident(ulid::Ulid);
+
+         impl #ident {
+            pub fn new(ulid: ulid::Ulid) -> Self {
+                Self(ulid)
+            }
+
+            pub fn get(&self) -> &ulid::Ulid {
+                &self.0
+            }
+        }
+
+        impl std::fmt::Display for #ident {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl From<ulid::Ulid> for #ident {
+            fn from(ulid: ulid::Ulid) -> Self {
+                Self(ulid)
+            }
+        }
+
+        impl TryFrom<&str> for #ident {
+            type Error = ulid::DecodeError;
+
+            fn try_from(string: &str) -> Result<Self, Self::Error> {
+                Ok(Self(ulid::Ulid::from_string(string)?))
+            }
+        }
+
+        impl TryFrom<String> for #ident {
+            type Error = ulid::DecodeError;
+
+            fn try_from(string: String) -> Result<Self, Self::Error> {
+                Self::try_from(string.as_str())
+            }
+        }
+    };
+
+    newtype.into()
+}
+
+fn derives() -> proc_macro2::TokenStream {
+    let mut derives = quote! {
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    };
+
+    derives.extend(derive_serde());
+
+    derives
+}
+
+#[cfg(feature = "serde")]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {
+        #[derive(serde::Deserialize, serde::Serialize)]
+    }
+}
+
+#[cfg(not(feature = "serde"))]
+fn derive_serde() -> proc_macro2::TokenStream {
+    quote! {}
+}

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -1,0 +1,98 @@
+#[cfg(feature = "ulid")]
+use std::convert::TryInto;
+#[cfg(feature = "ulid")]
+use typed_fields::ulid;
+#[cfg(feature = "ulid")]
+use ulid::Ulid;
+
+#[cfg(feature = "ulid")]
+ulid!(TestUlid);
+
+#[cfg(feature = "ulid")]
+#[test]
+fn get() {
+    let input = Ulid::new();
+
+    let ulid = TestUlid::new(input);
+
+    assert_eq!(input, *ulid.get());
+}
+
+#[cfg(all(feature = "serde", feature = "ulid"))]
+#[test]
+fn trait_deserialize() {
+    let json = r#""01ARZ3NDEKTSV4RRFFQ69G5FAV""#;
+
+    let ulid: TestUlid = serde_json::from_str(json).unwrap();
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_display() {
+    let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+}
+
+#[cfg(all(feature = "serde", feature = "ulid"))]
+#[test]
+fn trait_serialize() {
+    let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());
+
+    let json = serde_json::to_string(&ulid).unwrap();
+
+    assert_eq!(r#""01ARZ3NDEKTSV4RRFFQ69G5FAV""#, json);
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_try_from_str() {
+    let _ulid: TestUlid = "01ARZ3NDEKTSV4RRFFQ69G5FAV".try_into().unwrap();
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_try_from_str_with_random_string() {
+    let ulid = TestUlid::try_from("test");
+
+    assert!(ulid.is_err());
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_try_from_string() {
+    let _ulid: TestUlid = String::from("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+        .try_into()
+        .unwrap();
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_try_from_string_with_random_string() {
+    let ulid = TestUlid::try_from(String::from("test"));
+
+    assert!(ulid.is_err());
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUlid>();
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUlid>();
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn trait_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUlid>();
+}


### PR DESCRIPTION
A new macro has been created that generates a new type that is backed by a `ULID` from the `ulid`[^1] crate.

[^1]: https://crates.io/crates/ulid