### PR TITLE
Combine continuous integration into a single job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,5 @@
 ---
-name: Rust
+name: Continuous Integration
 
 "on":
   push:
@@ -9,175 +9,9 @@ name: Rust
   workflow_dispatch:
 
 jobs:
-  detect-changes:
-    name: Detect changes
+  ci:
+    name: All checks
     runs-on: ubuntu-latest
-
-    outputs:
-      any_changed: ${{ steps.detect-changes.outputs.any_changed }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Get changed files
-        id: detect-changes
-        uses: tj-actions/changed-files@v45
-        with:
-          files: |
-            .github/workflows/rust.yml
-            Earthfile
-            **/*.rs
-            **/*.toml
-
-      - name: Print changed files
-        run: |
-          for file in ${{ steps.detect-changes.outputs.all_changed_files }}; do
-            echo "$file"
-          done
-
-  doc:
-    name: Build docs
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Compile the documentation
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +doc
-
-  features:
-    name: Test features
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Test combinations of features
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +features
-
-  lint:
-    name: Lint code
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run Clippy
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +lint
-
-  minimal:
-    name: Test minimal versions
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run tests with minimal versions
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +deps-minimal
-
-  msrv:
-    name: MSRV
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        msrv: [1.61.0]
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Check code with MSRV
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +msrv
-
-  style:
-    name: Check style
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run Rustfmt
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +format
-
-  test:
-    name: Run tests
-    runs-on: ubuntu-latest
-
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
 
     steps:
       - name: Checkout code
@@ -192,7 +26,7 @@ jobs:
       - name: Run tests with test coverage
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --allow-privileged --org jdno --sat xsmall-amd64-1 --strict +test --SAVE_REPORT=yes
+        run: earthly --allow-privileged --org jdno --sat xsmall-amd64-1 --strict +all --SAVE_REPORT=yes
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5

--- a/Earthfile
+++ b/Earthfile
@@ -4,6 +4,16 @@ PROJECT jdno/typed-fields
 FROM rust:1.82.0-slim
 WORKDIR /typed-fields
 
+all:
+    BUILD +deps-latest
+    BUILD +deps-minimal
+    BUILD +doc
+    BUILD +features
+    BUILD +format
+    BUILD +lint
+    BUILD +msrv
+    BUILD +test
+
 os:
     # Install clippy and rustfmt
     RUN rustup component add clippy rustfmt


### PR DESCRIPTION
Now that we are using Earthly to configure our continuous integration, we want to use it to optimize its execution as well. Earthly calculates a directed acyclic graph with all steps, and then parallelizes them as much as possible. Together with its aggressive caching, we expect this to cut down the execution time of CI.