### PR TITLE
Ignore `non_local_definitions` warning

### DIFF
--- a/tests/name.rs
+++ b/tests/name.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 use typed_fields::name;
 
 name!(TestName);

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 use typed_fields::number;
 
 number!(TestId);

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 #[cfg(feature = "secret")]
 use typed_fields::secret;
 

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 #[cfg(feature = "ulid")]
 use std::convert::TryInto;
 #[cfg(feature = "ulid")]

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 #[cfg(feature = "url")]
 use std::convert::TryInto;
 

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -1,3 +1,6 @@
+// TODO: Debug this warning, fix its cause, and remove this directive.
+#![allow(non_local_definitions)]
+
 #[cfg(feature = "uuid")]
 use std::convert::TryInto;
 


### PR DESCRIPTION
Recent versions of Rust warn that the code violates the non-local definitions rule[^1]. The error message points to `serde::Deserialize`, which is outside our control. It is not unlikely that our proc marcos are to blame, but that requires further investigation.

For now, the warnings have been turned off and a `TODO` has been added to every `allow` statement.

[^1]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/non_local_def/static.NON_LOCAL_DEFINITIONS.html