### PR TITLE
Unlock dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,18 +30,18 @@ url = ["dep:url"]
 uuid = ["dep:uuid"]
 
 [dependencies]
-proc-macro2 = "1.0.63"
-quote = "1.0.28"
-secrecy = { version = "0.4.1", optional = true }
-serde = { version = "1.0.103", features = ["derive"], optional = true }
-syn = { version = "2.0.31", features = ["extra-traits"] }
-ulid = { version = "1.1.3", optional = true }
-url = { version = "2.2.0", optional = true }
-uuid = { version = "1.0.0", optional = true }
+proc-macro2 = ">=1.0.63"
+quote = ">=1.0.28"
+secrecy = { version = ">=0.4.1, <0.10.0", optional = true }
+serde = { version = ">=1.0.103", features = ["derive"], optional = true }
+syn = { version = ">=2.0.31", features = ["extra-traits"] }
+ulid = { version = ">=1.1.3", optional = true }
+url = { version = ">=2.2.0", optional = true }
+uuid = { version = ">=1.0.0", optional = true }
 
 # This is a transient dependency of the `ulid` feature, but we need to set its
 # minimum version that is compatible with this crate.
-zerocopy = { version = "0.7.31", optional = true }
+zerocopy = { version = ">=0.7.31", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"


### PR DESCRIPTION
This crate does not require specific versions for its dependencies. In fact, in an effort to increase compatibility with its dependants, it is tested against both the lowest and highest versions of its dependencies.

While this was always the intention, the `Cargo.toml` was not using the correct way to specify the dependencies to actually support this behavior. This has been fixed.