### PR TITLE
Check latest dependencies on GitHub Actions runners

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run tests with latest dependency versions
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --org jdno --sat xsmall-amd64-1 +rust-deps-latest
+        run: earthly --ci +rust-deps-latest


### PR DESCRIPTION
The check with the latest dependencies was forgotten when switching to GitHub Actions runners.