### PR TITLE
Bump `secrecy` crate to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,9 +169,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "secrecy"
-version = "0.4.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb052cf770a381fa9a6ee63038ff9a0b11d30abb53be970672e950649ff0bfb"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ uuid = ["dep:uuid"]
 [dependencies]
 proc-macro2 = ">=1.0.63"
 quote = ">=1.0.28"
-secrecy = { version = ">=0.4.1, <0.10.0", optional = true }
+secrecy = { version = ">=0.10.3", optional = true }
 serde = { version = ">=1.0.103", features = ["derive"], optional = true }
 syn = { version = ">=2.0.31", features = ["extra-traits"] }
 ulid = { version = ">=1.1.3", optional = true }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -14,7 +14,7 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
 
         impl #ident {
             pub fn new(secret: &str) -> Self {
-                Self(secrecy::SecretString::new(String::from(secret)))
+                Self(String::from(secret).into())
             }
 
             pub fn expose(&self) -> &str {
@@ -31,13 +31,13 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
 
         impl From<&str> for #ident {
             fn from(secret: &str) -> #ident {
-                #ident(secrecy::SecretString::new(String::from(secret)))
+                #ident(String::from(secret).into())
             }
         }
 
         impl From<String> for #ident {
             fn from(secret: String) -> #ident {
-                #ident(secrecy::SecretString::new(secret))
+                #ident(secret.into())
             }
         }
     };


### PR DESCRIPTION
The `secrecy` crate introduced a lot of backwards-incompatible changes in version 0.10. The dependency has been bumped to its latest version, since maintaining backwards compatibility does not seem worth it.