### PR TITLE
Publish crate using Earthly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install earthly
+        uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 0.8
 
-      - name: Publish crate
-        run: cargo publish -v --all-features
+      - name: Publish with Earthly
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+        run: earthly --ci +rust-publish


### PR DESCRIPTION
The publishing workflow has been changed to use the Earthly target that was created to publish the crate to crates.io.