### PR TITLE
Pass env variable as secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-publish
+        run: earthly --ci --secret CARGO_REGISTRY_TOKEN +rust-publish


### PR DESCRIPTION
Earthly does not automatically pass environment variables to its targets and requires callers to do it manually to ensure deterministic builds.