### PR TITLE
Include README in releases

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -140,6 +140,9 @@ rust-msrv:
 rust-publish:
     FROM +rust-build
 
+    # Copy additional files for the release into the container
+    COPY README.md .
+
     # Publish the crate to crates.io
     RUN --secret CARGO_REGISTRY_TOKEN cargo publish -v --all-features --token "$CARGO_REGISTRY_TOKEN"
 


### PR DESCRIPTION
When publishing a release, we want to include the README in the crate so that it gets rendered on crates.io. But so far, we only copy Rust files into the build container. A new step has been added to the publish target to copy additional files into the container before publishing the crate to crates.io.