### PR TITLE
Use a remote cache with Earthly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ name: Continuous Integration
   pull_request:
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
   json-format:
     name: Format JSON
@@ -216,7 +220,7 @@ jobs:
       - name: Run tests with test coverage
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --allow-privileged --strict +rust-test --SAVE_REPORT=yes
+        run: earthly --allow-privileged --strict --remote-cache=ghcr.io/jdno/typed-fields:cache-run-tests +rust-test --SAVE_REPORT=yes
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Run tests with test coverage
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --allow-privileged --strict --remote-cache=ghcr.io/jdno/typed-fields:cache-run-tests +rust-test --SAVE_REPORT=yes
+        run: earthly --allow-privileged --push --remote-cache=ghcr.io/jdno/typed-fields:cache-run-tests --strict +rust-test --SAVE_REPORT=yes
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install earthly
         uses: earthly/actions-setup@v1
         with:

--- a/Earthfile
+++ b/Earthfile
@@ -71,11 +71,11 @@ rust-container:
     # Install clippy and rustfmt
     RUN rustup component add clippy rustfmt
 
-    # Install system-level dependencies
-    RUN apt update && apt upgrade -y && apt install -y curl libssl-dev pkg-config
-
 rust-tarpaulin-container:
     FROM +rust-container
+
+    # Install system-level dependencies
+    RUN apt update && apt upgrade -y && apt install -y curl libssl-dev pkg-config
 
     # Install cargo-tarpaulin
     RUN cargo install cargo-tarpaulin

--- a/Earthfile
+++ b/Earthfile
@@ -74,6 +74,15 @@ rust-container:
     # Install system-level dependencies
     RUN apt update && apt upgrade -y && apt install -y curl libssl-dev pkg-config
 
+rust-tarpaulin-container:
+    FROM +rust-container
+
+    # Install cargo-tarpaulin
+    RUN cargo install cargo-tarpaulin
+
+    # Cache the container
+    SAVE IMAGE --cache-hint
+
 rust-sources:
     FROM +rust-container
 
@@ -164,10 +173,10 @@ rust-test:
     # Optionally save the report to the local filesystem
     ARG SAVE_REPORT=""
 
-    FROM +rust-build
+    FROM +rust-tarpaulin-container
 
-    # Install cargo-tarpaulin
-    RUN cargo install cargo-tarpaulin
+    # Copy the source code in a cache-friendly way
+    DO +COPY_RUST_SOURCES
 
     # Run the tests and measure the code coverage
     # --privileged is required by tarpaulin to set flags on the binary


### PR DESCRIPTION
Earthly supports using a remote cache to speed up its runs. The documentation is only available for an older version, but the command-line flag still exists in the most recent version. The cache works by pushing a "fake" Docker tag, for which we are using GitHub's container registry.