### PR TITLE
Allow to pass attributes to newtypes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,9 @@
 #![warn(missing_docs)]
 
 use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use syn::parse::{Parse, ParseStream};
+use syn::Attribute;
 
 mod name;
 mod number;
@@ -194,4 +197,35 @@ pub fn url(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn uuid(input: TokenStream) -> TokenStream {
     uuid::uuid_impl(input)
+}
+
+/// The token stream of each macro invocation
+///
+/// This struct represents the token stream of each macro invocation. Consider
+/// the following example:
+///
+/// ```rust
+/// use typed_fields::name;
+///
+/// name!(
+///     /// This is a doc comment
+///     TestName
+/// )
+/// ```
+///
+/// In this example, `attrs` will contain the doc comment and `ident` will
+/// contain the identifier `TestName`. More attributes can be added by the user,
+/// e.g. additional derives.
+struct Input {
+    attrs: Vec<Attribute>,
+    ident: Ident,
+}
+
+impl Parse for Input {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let ident: Ident = input.parse()?;
+
+        Ok(Self { attrs, ident })
+    }
 }

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn name_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(String);
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn number_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(i64);
 

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn secret_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(secrecy::SecretString);
 

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn ulid_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(ulid::Ulid);
 

--- a/src/url.rs
+++ b/src/url.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn url_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(url::Url);
 

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -1,14 +1,16 @@
 use proc_macro::TokenStream;
 
-use proc_macro2::Ident;
 use quote::quote;
 use syn::parse_macro_input;
 
+use crate::Input;
+
 pub fn uuid_impl(input: TokenStream) -> TokenStream {
-    let ident = parse_macro_input!(input as Ident);
+    let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
     let newtype = quote! {
+        #(#attrs)*
         #derives
         pub struct #ident(uuid::Uuid);
 

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -3,7 +3,10 @@
 
 use typed_fields::name;
 
-name!(TestName);
+name!(
+    /// A doc comment for the test name
+    TestName
+);
 
 #[test]
 fn get() {

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -3,7 +3,10 @@
 
 use typed_fields::number;
 
-number!(TestId);
+number!(
+    /// A doc comment for the test id
+    TestId
+);
 
 #[test]
 fn get() {

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -5,7 +5,10 @@
 use typed_fields::secret;
 
 #[cfg(feature = "secret")]
-secret!(TestSecret);
+secret!(
+    /// A doc comment for the test secret
+    TestSecret
+);
 
 #[cfg(feature = "secret")]
 #[test]

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -9,7 +9,10 @@ use typed_fields::ulid;
 use ulid::Ulid;
 
 #[cfg(feature = "ulid")]
-ulid!(TestUlid);
+ulid!(
+    /// A doc comment for the test ULID
+    TestUlid
+);
 
 #[cfg(feature = "ulid")]
 #[test]

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -11,7 +11,10 @@ use url::Url;
 use typed_fields::url;
 
 #[cfg(feature = "url")]
-url!(TestUrl);
+url!(
+    /// A doc comment for the test URL
+    TestUrl
+);
 
 #[cfg(feature = "url")]
 #[test]

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -10,7 +10,10 @@ use typed_fields::uuid;
 use uuid::uuid as uuid_v4;
 
 #[cfg(feature = "uuid")]
-uuid!(TestUuid);
+uuid!(
+    /// A doc comment for the test UUID
+    TestUuid
+);
 
 #[cfg(feature = "uuid")]
 #[test]


### PR DESCRIPTION
The procedural macros have been modified to allow users to pass additional attributes to the generated newtypes. This allows to document the newtypes and can be used to add additional `derive` macros, for example.

```rust
use typed_fields::name;

name!(
    /// A doc comment for the test name
    #[derive(MyCustomDeriveMacro)]
    TestName
);
```