### PR TITLE
Document the generated code

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -15,10 +15,29 @@ pub fn name_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(String);
 
         impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from anything that implements
+            /// the `Into<String>` trait. This includes `&str`, `String`, and
+            /// other types that can be converted into a `String`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use typed_fields::name;
+            ///
+            /// name!(Name);
+            ///
+            /// let name = Name::new("name");
+            /// ```
             pub fn new(name: impl Into<String>) -> Self {
                 Self(name.into())
             }
 
+            /// Get the inner value of the `#ident`
+            ///
+            /// This method returns a reference to the inner value of the
+            /// `#ident`.
             pub fn get(&self) -> &str {
                 &self.0
             }

--- a/src/number.rs
+++ b/src/number.rs
@@ -15,10 +15,26 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(i64);
 
         impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from an `i64`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use typed_fields::number;
+            ///
+            /// number!(Number);
+            ///
+            /// let number = Number::new(0);
+            /// ```
             pub fn new(id: i64) -> Self {
                 Self(id)
             }
 
+            /// Get the inner value of the `#ident`
+            ///
+            /// This method returns a copy of the inner value of the `#ident`.
             pub fn get(&self) -> i64 {
                 self.0
             }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -15,10 +15,27 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(secrecy::SecretString);
 
         impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from a `&str`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use typed_fields::secret;
+            ///
+            /// secret!(Secret);
+            ///
+            /// let secret = Secret::new("secret");
+            /// ```
             pub fn new(secret: &str) -> Self {
                 Self(String::from(secret).into())
             }
 
+            /// Expose the secret's inner value
+            ///
+            /// This method returns a reference to the exposed value of the
+            /// `#ident`.
             pub fn expose(&self) -> &str {
                 use secrecy::ExposeSecret;
                 self.0.expose_secret()

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -15,10 +15,28 @@ pub fn ulid_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(ulid::Ulid);
 
          impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from a `Ulid`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use ulid::Ulid;
+            /// use typed_fields::ulid;
+            ///
+            /// ulid!(MyUlid);
+            ///
+            /// let ulid = MyUlid::new(Ulid::new());
+            /// ```
             pub fn new(ulid: ulid::Ulid) -> Self {
                 Self(ulid)
             }
 
+            /// Get the inner value of the `#ident`
+            ///
+            /// This method returns a reference to the inner value of the
+            /// `#ident`.
             pub fn get(&self) -> &ulid::Ulid {
                 &self.0
             }

--- a/src/url.rs
+++ b/src/url.rs
@@ -15,10 +15,28 @@ pub fn url_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(url::Url);
 
          impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from a `URL`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use typed_fields::url;
+            /// use url::Url;
+            ///
+            /// url!(MyUrl);
+            ///
+            /// let url = MyUrl::new(Url::parse("https://example.com").unwrap());
+            /// ```
             pub fn new(url: url::Url) -> Self {
                 Self(url)
             }
 
+            /// Get the inner value of the `#ident`
+            ///
+            /// This method returns a reference to the inner value of the
+            /// `#ident`.
             pub fn get(&self) -> &url::Url {
                 &self.0
             }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -15,10 +15,27 @@ pub fn uuid_impl(input: TokenStream) -> TokenStream {
         pub struct #ident(uuid::Uuid);
 
          impl #ident {
+            /// Create a new `#ident`
+            ///
+            /// This method creates a new `#ident` from a `Uuid`.
+            ///
+            /// # Example
+            ///
+            /// ```
+            /// use typed_fields::uuid;
+            ///
+            /// uuid!(MyUuid);
+            ///
+            /// let uuid = MyUuid::new(Uuid::new_v4());
+            /// ```
             pub fn new(uuid: uuid::Uuid) -> Self {
                 Self(uuid)
             }
 
+            /// Get the inner value of the `#ident`
+            ///
+            /// This method returns a reference to the inner value of the
+            /// `#ident`.
             pub fn get(&self) -> &uuid::Uuid {
                 &self.0
             }


### PR DESCRIPTION
The code that is generated by the macros has been documented so that certain optional lints in Rust and Clippy won't fail due to missing documentation in the expanded code.