### PR TITLE
Update Earthfile with Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,13 +12,7 @@
     enabled: true,
   },
 
-  customManagers: [
-    {
-      customType: "regex",
-      fileMatch: ["^Earthfile$"],
-      matchStrings: ["rust:(?<currentValue>.*?)(-[\\w]+)?$"],
-      depNameTemplate: "rust",
-      datasourceTemplate: "docker",
-    },
-  ],
+  dockerfile: {
+    fileMatch: ["^Earthfile$"],
+  },
 }


### PR DESCRIPTION
Docker images in the `Earthfile` are now updated using Renovate. The workaround for this isn't perfect, but good enough until proper support is implemented inside Renovate.