### PR TITLE
Refactor Earthfile and GitHub Actions workflow

### DIFF
--- a/.earthly/markdown/Earthfile
+++ b/.earthly/markdown/Earthfile
@@ -1,0 +1,16 @@
+VERSION 0.8
+
+LINT:
+    FUNCTION
+
+    FROM node:alpine
+    WORKDIR /typed-fields
+
+    # Install markdownlint
+    RUN npm install -g markdownlint-cli
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check the Markdown for linting errors
+    RUN markdownlint **/*.md

--- a/.earthly/prettier/Earthfile
+++ b/.earthly/prettier/Earthfile
@@ -1,0 +1,29 @@
+VERSION 0.8
+
+PRETTIER:
+    FUNCTION
+
+    ARG EXTENSION="*"
+    ARG FIX="false"
+
+    FROM node:alpine
+    WORKDIR /typed-fields
+
+    # Install prettier
+    RUN npm install -g prettier
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check or fix the formatting of the source code
+    LET flag = "check"
+    IF [ "$FIX" = "true" ]
+        SET flag = "write"
+    END
+
+    RUN prettier --$flag --ignore-unknown "**/*.$EXTENSION"
+
+    # Save changes back to the local filesystem
+    IF [ "$FIX" = "true" ]
+        SAVE ARTIFACT ./* AS LOCAL .
+    END

--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -1,0 +1,174 @@
+VERSION 0.8
+
+IMPORT github.com/earthly/lib/rust AS rust
+
+COPY_RUST_SOURCES:
+    FUNCTION
+
+    # Copy the source code in a cache-friendly way
+    COPY --keep-ts Cargo.toml Cargo.lock ./
+    COPY --keep-ts --dir src tests ./
+
+DEPS_LATEST:
+    FUNCTION
+
+    DO +SOURCES
+
+    # Switch to beta toolchain
+    RUN rustup default beta
+
+    # Update the dependencies to the latest versions
+    DO rust+CARGO --args="update"
+
+    # Run tests to ensure the latest versions are compatible
+    ENV RUSTFLAGS="-D deprecated"
+    DO rust+CARGO --args="test --all-features --all-targets --locked"
+
+DEPS_MINIMAL:
+    FUNCTION
+
+    DO +SOURCES
+
+    # Switch to nightly toolchain
+    RUN rustup default nightly
+
+    # Set minimal versions for dependencies
+    DO rust+CARGO --args="update -Z direct-minimal-versions"
+
+    # Run tests to ensure the minimal versions are compatible
+    DO rust+CARGO --args="test --all-features --all-targets --locked"
+
+DOCS:
+    FUNCTION
+
+    DO +SOURCES
+
+    # Generate the documentation
+    DO rust+CARGO --args="doc --all-features --no-deps"
+
+    # Save the documentation to the local filesystem
+    SAVE ARTIFACT target/doc AS LOCAL target/doc
+
+FEATURES:
+    FUNCTION
+
+    DO +BUILD
+
+    # Install cargo-hack
+    DO rust+CARGO --args="install cargo-hack"
+
+    # Test combinations of features
+    DO rust+CARGO --args="hack --feature-powerset check --lib --tests"
+
+FORMAT:
+    FUNCTION
+
+    ARG FIX="false"
+
+    DO +SOURCES
+
+    # Check or fix the formatting of the source code
+    IF [ "$FIX" = "true" ]
+        DO rust+CARGO --args="fmt --all"
+    ELSE
+        DO rust+CARGO --args="fmt --all --check"
+    END
+
+LINT:
+    FUNCTION
+
+    DO +BUILD
+
+    # Check the code for linting errors
+    DO rust+CARGO --args="clippy --all-targets --all-features -- -D warnings"
+
+MSRV:
+    FUNCTION
+
+    ARG MSRV="1.71.1"
+
+    FROM "rust:$MSRV-slim"
+
+    # Copy the source code in a cache-friendly way
+    DO +COPY_RUST_SOURCES
+
+    # Check that the project compiles with the MSRV
+    DO rust+CARGO --args="+$MSRV check --all-features --all-targets"
+
+PUBLISH:
+    FUNCTION
+
+    DO +BUILD
+
+    # Copy additional files for the release into the container
+    COPY README.md .
+
+    # Publish the crate to crates.io
+    DO rust+CARGO --secret CARGO_REGISTRY_TOKEN --args="cargo publish -v --all-features --token $CARGO_REGISTRY_TOKEN"
+
+TEST:
+    FUNCTION
+
+    # Optionally save the report to the local filesystem
+    ARG SAVE_REPORT=""
+
+    FROM +tarpaulin-container
+
+    # Copy the source code in a cache-friendly way
+    DO +COPY_RUST_SOURCES
+
+    # Run the tests and measure the code coverage
+    # --privileged is required by tarpaulin to set flags on the binary
+    RUN --privileged cargo tarpaulin \
+        --all-features \
+        --all-targets \
+        --out Xml \
+        --skip-clean \
+        --verbose
+
+    # Save the coverage report
+    IF [ "$SAVE_REPORT" != "" ]
+        SAVE ARTIFACT cobertura.xml AS LOCAL cobertura.xml
+    END
+
+CONTAINER:
+    FUNCTION
+
+    FROM rust:1.84.1-slim
+    WORKDIR /typed-fields
+
+    # Initialize Rust
+    DO rust+INIT --keep_fingerprints=true
+
+    # Install clippy and rustfmt
+    RUN rustup component add clippy rustfmt
+
+TARPAULIN_CONTAINER:
+    FUNCTION
+
+    DO +CONTAINER
+
+    # Install system-level dependencies
+    RUN apt update && apt upgrade -y && apt install -y curl libssl-dev pkg-config
+
+    # Install cargo-tarpaulin
+    DO rust+CARGO --args="install cargo-tarpaulin"
+
+    # Cache the container
+    SAVE IMAGE --cache-hint
+
+SOURCES:
+    FUNCTION
+
+    DO +CONTAINER
+
+    # Copy the source code in a cache-friendly way
+    DO +COPY_RUST_SOURCES
+
+BUILD:
+    FUNCTION
+
+    DO +SOURCES
+
+    # Build the project
+    DO rust+CARGO --args="build --all-features --all-targets --locked"

--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -89,6 +89,9 @@ MSRV:
 
     FROM "rust:$MSRV-slim"
 
+    # Initialize Rust
+    DO rust+INIT --keep_fingerprints=true
+
     # Copy the source code in a cache-friendly way
     DO +COPY_RUST_SOURCES
 

--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -44,7 +44,7 @@ DOCS:
     DO +SOURCES
 
     # Generate the documentation
-    DO rust+CARGO --args="doc --all-features --no-deps"
+    DO rust+CARGO --args="doc --all-features --no-deps" --output="doc/.+"
 
     # Save the documentation to the local filesystem
     SAVE ARTIFACT target/doc AS LOCAL target/doc

--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -115,7 +115,7 @@ TEST:
     # Optionally save the report to the local filesystem
     ARG SAVE_REPORT=""
 
-    FROM +tarpaulin-container
+    DO +TARPAULIN_CONTAINER
 
     # Copy the source code in a cache-friendly way
     DO +COPY_RUST_SOURCES

--- a/.earthly/toml/Earthfile
+++ b/.earthly/toml/Earthfile
@@ -1,0 +1,24 @@
+VERSION 0.8
+
+FORMAT:
+    FUNCTION
+
+    ARG FIX="false"
+
+    FROM tamasfe/taplo:latest
+    WORKDIR /typed-fields
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check or fix the formatting of the source code
+    IF [ "$FIX" = "true" ]
+       RUN taplo fmt
+    ELSE
+        RUN taplo fmt --check
+    END
+
+    # Save changes back to the local filesystem
+    IF [ "$FIX" = "true" ]
+        SAVE ARTIFACT ./* AS LOCAL .
+    END

--- a/.earthly/yaml/Earthfile
+++ b/.earthly/yaml/Earthfile
@@ -1,0 +1,13 @@
+VERSION 0.8
+
+LINT:
+    FUNCTION
+
+    FROM pipelinecomponents/yamllint:latest
+    WORKDIR /typed-fields
+
+    # Copy the source code into the container
+    COPY . .
+
+    # Check the YAML files for linting errors
+    RUN yamllint .

--- a/.earthlyignore
+++ b/.earthlyignore
@@ -1,1 +1,2 @@
+.git
 /target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,16 @@
 name: Continuous Integration
 
 "on":
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 
-permissions:
-  packages: write
-  contents: read
-
 jobs:
-  json-format:
-    name: Format JSON
+  targets:
+    name: Enumerate Earthly targets
     runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.export-targets.outputs.targets }}
 
     steps:
       - name: Checkout code
@@ -27,185 +23,24 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
 
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +json-format
+      - name: Export targets
+        id: export-targets
+        run: echo "targets=$(earthly ls | jq -cnR '[inputs | sub("\\+"; "") | select(startswith("check") or startswith("format") or startswith("lint") or startswith("test"))]')" >> "$GITHUB_OUTPUT"
 
-  markdown-format:
-    name: Format Markdown
+  checks:
+    name: Check
     runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+    permissions:
+      packages: write
+      contents: read
 
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
+    needs: targets
 
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +markdown-format
-
-  markdown-lint:
-    name: Lint Markdown
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +markdown-lint
-
-  rust-deps-latest:
-    name: Test latest dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-deps-latest
-
-  rust-deps-minimal:
-    name: Test minimal dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-deps-minimal
-
-  rust-doc:
-    name: Compile documentation
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-doc
-
-  rust-features:
-    name: Test features
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-deps-latest
-
-  rust-format:
-    name: Format Rust
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-format
-
-  rust-lint:
-    name: Lint Rust
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-lint
-
-  rust-msrv:
-    name: Check MSRV
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-msrv
-
-  rust-test:
-    name: Run tests
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.targets.outputs.matrix) }}
 
     steps:
       - name: Checkout code
@@ -224,57 +59,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
 
-      - name: Run tests with test coverage
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --allow-privileged --push --remote-cache=ghcr.io/jdno/typed-fields:cache-run-tests --strict +rust-test --SAVE_REPORT=yes
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
-        continue-on-error: true
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report
-          path: cobertura.xml
-
-  yaml-format:
-    name: Format YAML
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
       - name: Run check with Earthly
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +yaml-format
-
-  yaml-lint:
-    name: Lint YAML
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install earthly
-        uses: earthly/actions-setup@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 0.8
-
-      - name: Run check with Earthly
-        env:
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +yaml-lint
+        run: earthly --allow-privileged --ci --push --remote-cache=ghcr.io/jdno/typed-fields-earthly-cache:${{ matrix.target }} +${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "targets=$(earthly ls | jq -cnR '[inputs | sub("\\+"; "") | select(startswith("check-") or startswith("format-") or startswith("lint-") or startswith("test-"))]')" >> "$GITHUB_OUTPUT"
 
   checks:
-    name: Check
+    name: ${{ matrix.target }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Export targets
         id: export-targets
-        run: echo "targets=$(earthly ls | jq -cnR '[inputs | sub("\\+"; "") | select(startswith("check") or startswith("format") or startswith("lint") or startswith("test"))]')" >> "$GITHUB_OUTPUT"
+        run: echo "targets=$(earthly ls | jq -cnR '[inputs | sub("\\+"; "") | select(startswith("check-") or startswith("format-") or startswith("lint-") or startswith("test-"))]')" >> "$GITHUB_OUTPUT"
 
   checks:
     name: Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,14 @@ jobs:
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
         run: earthly --allow-privileged --ci --push --remote-cache=ghcr.io/jdno/typed-fields-earthly-cache:${{ matrix.target }} +${{ matrix.target }}
+
+  success:
+    name: All checks succeeded
+    runs-on: ubuntu-latest
+
+    needs: checks
+    if: always()
+
+    steps:
+      - name: Check if all checks succeeded
+        run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -2,7 +2,7 @@
 name: Dependencies
 
 "on":
-  push:
+  pull_request:
     paths:
       - .github/workflows/dependencies.yml
       - Earthfile
@@ -16,9 +16,20 @@ jobs:
     name: Latest versions
     runs-on: ubuntu-latest
 
+    permissions:
+      packages: write
+      contents: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install earthly
         uses: earthly/actions-setup@v1

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Run tests with latest dependency versions
         env:
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci +rust-deps-latest
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/typed-fields-earthly-cache:check-latest-deps +check-latest-deps

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
           EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
-        run: earthly --ci --secret CARGO_REGISTRY_TOKEN +rust-publish
+        run: earthly --ci --push --remote-cache=ghcr.io/jdno/typed-fields-earthly-cache:publish-crate --secret CARGO_REGISTRY_TOKEN  +publish-crate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 # pre-commit configuration
 #
-# We use pre-commit to enforce a consistency in our repositories. By default,
-# YAML and Markdown files get linted, and Prettier runs to auto-format the file
-# types it supports. Depending on the project, other rules can be added here to
-# support the needs of the project.
+# We use pre-commit to enforce a consistent style in our repositories. The hooks
+# check for a few common issues with files, and then execute the `+pre-commit`
+# target in Earthly to run the same checks as the CI pipeline.
 #
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
@@ -13,29 +12,14 @@ repos:
     rev: v5.0.0
     hooks:
       - id: check-added-large-files
-        args: ["--maxkb=1024"]
       - id: check-case-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+  - repo: https://github.com/hongkongkiwi/earthly-precommit
+    rev: v0.0.5
     hooks:
-      - id: markdownlint
-  - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
-    hooks:
-      - id: yamllint
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        args: ["--cache-location=.prettiercache"]
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: v1.0
-    hooks:
-      - id: clippy
-        args: [--all-features, --all-targets, --, -D, warnings]
-      - id: cargo-check
-      - id: fmt
-        args: [--all, --]
+      - id: earthly-target
+        name: run Earthly checks
+        args: ["./Earthfile", "+pre-commit", "--FIX=true"]
+        files: .*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ all-features = true
 [features]
 secret = ["dep:secrecy"]
 serde = [
-    "dep:serde",
-    "secrecy?/serde",
-    "ulid?/serde",
-    "url?/serde",
-    "uuid?/serde",
+  "dep:serde",
+  "secrecy?/serde",
+  "ulid?/serde",
+  "url?/serde",
+  "uuid?/serde",
 ]
 ulid = ["dep:ulid"]
 url = ["dep:url"]

--- a/Earthfile
+++ b/Earthfile
@@ -44,7 +44,8 @@ check-minimal-deps:
     DO ./.earthly/rust+DEPS_MINIMAL
 
 check-msrv:
-    DO ./.earthly/rust+MSRV --MSRV="1.71.1"
+    ARG MSRV="1.71.1"
+    DO ./.earthly/rust+MSRV --MSRV="$MSRV"
 
 format-json:
     ARG FIX="false"

--- a/Earthfile
+++ b/Earthfile
@@ -1,6 +1,10 @@
 VERSION 0.8
 PROJECT jdno/typed-fields
 
+# This project's continuous integration pipeline executes all Earthly targets
+# that start with the prefixes `check-`, `format-`, `lint-`, and `test-`. Fixing
+# formatting issues is disabled to prevent parallely running targets from
+# overwriting each other's changes.
 checks:
     BUILD +check-docs
     BUILD +check-features

--- a/Earthfile
+++ b/Earthfile
@@ -1,209 +1,86 @@
 VERSION 0.8
 PROJECT jdno/typed-fields
 
-FROM rust:1.84.1-slim
-WORKDIR /typed-fields
+checks:
+    BUILD +check-docs
+    BUILD +check-features
+    BUILD +check-latest-deps
+    BUILD +check-minimal-deps
+    BUILD +check-msrv
+    BUILD +format-json --FIX="false"
+    BUILD +format-markdown --FIX="false"
+    BUILD +format-rust --FIX="false"
+    BUILD +format-toml --FIX="false"
+    BUILD +format-yaml --FIX="false"
+    BUILD +lint-markdown
+    BUILD +lint-rust
+    BUILD +lint-yaml
+    BUILD +test-rust
 
-all:
-    BUILD +json-format
-    BUILD +markdown-format
-    BUILD +markdown-lint
-    BUILD +rust-deps-latest
-    BUILD +rust-deps-minimal
-    BUILD +rust-doc
-    BUILD +rust-features
-    BUILD +rust-format
-    BUILD +rust-lint
-    BUILD +rust-msrv
-    BUILD +rust-test
-    BUILD +yaml-format
-    BUILD +yaml-lint
-
-COPY_SOURCES:
-    FUNCTION
-
-    # Copy the source code into the container
-    COPY . .
-
-COPY_RUST_SOURCES:
-    FUNCTION
-
-    # Copy the source code in a cache-friendly way
-    COPY --keep-ts Cargo.toml Cargo.lock ./
-    COPY --keep-ts --dir src tests ./
-
-json-format:
-    FROM +prettier-container
-
-    # Check the JSON formatting
-    RUN prettier --check **/*.{json,json5}
-
-markdown-format:
-    FROM +prettier-container
-
-    # Check the Markdown formatting
-    RUN prettier --check **/*.md
-
-markdown-lint:
-    FROM node:alpine
-    WORKDIR /typed-fields
-
-    # Install markdownlint
-    RUN npm install -g markdownlint-cli
-
-    # Copy the source code into the container
-    DO +COPY_SOURCES
-
-    # Check the Markdown for linting errors
-    RUN markdownlint **/*.md
-
-prettier-container:
-    FROM node:alpine
-    WORKDIR /typed-fields
-
-    # Install prettier
-    RUN npm install -g prettier
-
-    # Copy the source code into the container
-    DO +COPY_SOURCES
-
-rust-container:
-    # Install clippy and rustfmt
-    RUN rustup component add clippy rustfmt
-
-rust-tarpaulin-container:
-    FROM +rust-container
-
-    # Install system-level dependencies
-    RUN apt update && apt upgrade -y && apt install -y curl libssl-dev pkg-config
-
-    # Install cargo-tarpaulin
-    RUN cargo install cargo-tarpaulin
-
-    # Cache the container
-    SAVE IMAGE --cache-hint
-
-rust-sources:
-    FROM +rust-container
-
-    # Copy the source code in a cache-friendly way
-    DO +COPY_RUST_SOURCES
-
-rust-build:
-    FROM +rust-sources
-
-    # Build the project
-    RUN cargo build --all-features --locked
-
-rust-deps-latest:
-    FROM +rust-sources
-
-    # Switch to beta toolchain
-    RUN rustup default beta
-
-    # Update the dependencies to the latest versions
-    RUN cargo update
-
-    # Run tests to ensure the latest versions are compatible
-    RUN RUSTFLAGS="-D deprecated" cargo test --all-features --all-targets --locked
-
-rust-deps-minimal:
-    FROM +rust-sources
-
-    # Switch to nightly toolchain
-    RUN rustup default nightly
-
-    # Set minimal versions for dependencies
-    RUN cargo update -Z direct-minimal-versions
-
-    # Run tests to ensure the minimal versions are compatible
-    RUN cargo test --all-features --all-targets --locked
-
-rust-doc:
-    FROM +rust-sources
-
-    # Generate the documentation
-    RUN cargo doc --all-features --no-deps
-
-    # Save the documentation to the local filesystem
-    SAVE ARTIFACT target/doc AS LOCAL target/doc
-
-rust-features:
-    FROM +rust-build
-
-    # Install cargo-hack
-    RUN cargo install cargo-hack
-
-    # Test combinations of features
-    RUN cargo hack --feature-powerset check --lib --tests
-
-rust-format:
-    FROM +rust-sources
-
-    # Check the code formatting
-    RUN cargo fmt --all --check
-
-rust-lint:
-    FROM +rust-build
-
-    # Check the code for linting errors
-    RUN cargo clippy --all-targets --all-features -- -D warnings
-
-rust-msrv:
-    ARG MSRV="1.71.1"
-
-    FROM "rust:$MSRV-slim"
-
-    # Copy the source code in a cache-friendly way
-    DO +COPY_RUST_SOURCES
-
-    # Check that the project compiles with the MSRV
-    RUN cargo +$MSRV check --all-features --all-targets
-
-rust-publish:
-    FROM +rust-build
-
-    # Copy additional files for the release into the container
-    COPY README.md .
-
-    # Publish the crate to crates.io
-    RUN --secret CARGO_REGISTRY_TOKEN cargo publish -v --all-features --token "$CARGO_REGISTRY_TOKEN"
-
-rust-test:
-    # Optionally save the report to the local filesystem
-    ARG SAVE_REPORT=""
-
-    FROM +rust-tarpaulin-container
-
-    # Copy the source code in a cache-friendly way
-    DO +COPY_RUST_SOURCES
-
-    # Run the tests and measure the code coverage
-    # --privileged is required by tarpaulin to set flags on the binary
-    RUN --privileged cargo tarpaulin \
-        --all-features \
-        --all-targets \
-        --out Xml \
-        --skip-clean \
-        --verbose
-
-    # Save the coverage report
-    IF [ "$SAVE_REPORT" != "" ]
-        SAVE ARTIFACT cobertura.xml AS LOCAL cobertura.xml
+# These targets get executed by pre-commit before every commit. Some need to be
+# run sequentially to avoid overwriting each other's changes.
+pre-commit:
+    WAIT
+        BUILD +prettier
     END
+    WAIT
+        BUILD +format-toml
+    END
+    BUILD +format-rust
+    BUILD +lint-markdown
+    BUILD +lint-rust
+    BUILD +lint-yaml
 
-yaml-format:
-    FROM +prettier-container
+check-docs:
+    DO ./.earthly/rust+DOCS
 
-    # Check the YAML formatting
-    RUN prettier --check **/*.{yml,yaml}
+check-features:
+    DO ./.earthly/rust+FEATURES
 
-yaml-lint:
-    FROM pipelinecomponents/yamllint:latest
-    WORKDIR /typed-fields
+check-latest-deps:
+    DO ./.earthly/rust+DEPS_LATEST
 
-    # Copy the source code into the container
-    DO +COPY_SOURCES
+check-minimal-deps:
+    DO ./.earthly/rust+DEPS_MINIMAL
 
-    # Check the YAML files for linting errors
-    RUN yamllint .
+check-msrv:
+    DO ./.earthly/rust+MSRV --MSRV="1.71.1"
+
+format-json:
+    ARG FIX="false"
+    DO ./.earthly/prettier+PRETTIER --EXTENSION="{json,json5}" --FIX="$FIX"
+
+format-markdown:
+    ARG FIX="false"
+    DO ./.earthly/prettier+PRETTIER --EXTENSION="md" --FIX="$FIX"
+
+format-rust:
+    ARG FIX="false"
+    DO ./.earthly/rust+FORMAT --FIX="$FIX"
+
+format-toml:
+    ARG FIX="false"
+    DO ./.earthly/toml+FORMAT --FIX="$FIX"
+
+format-yaml:
+    ARG FIX="false"
+    DO ./.earthly/prettier+PRETTIER --EXTENSION="{yaml,yml}" --FIX="$FIX"
+
+lint-markdown:
+    DO ./.earthly/markdown+LINT
+
+lint-rust:
+    DO ./.earthly/rust+LINT
+
+lint-yaml:
+    DO ./.earthly/yaml+LINT
+
+prettier:
+    ARG FIX="false"
+    DO ./.earthly/prettier+PRETTIER --FIX="$FIX"
+
+publish-crate:
+    DO ./.earthly/rust+PUBLISH
+
+test-rust:
+    DO ./.earthly/rust+TEST


### PR DESCRIPTION
Earthly has been pushed to the absolute limits with this commit. The top-level `Earthfile` has been broken up into smaller files by reimplementing its targets as functions in different files inside the `.earthly` directory. Because Earthly uses the parent directory of each file as the context for each of its targets, the nested files can only define functions that are executed with the context of the calling target in the project root.

The root-level targets have been renamed to follow a simpler naming convention, which has made it possible to dynamically discover which targets to execute on GitHub Actions. Any target starting with `check`, `format`, `lint`, or `test` will get executed in CI.

The formatting targets have also been refactored to optionally write changes back to the project, making it possible to use them as pre-commit hooks.