### PR TITLE
Fix target that publishes the crate

### DIFF
--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -107,7 +107,7 @@ PUBLISH:
     COPY README.md .
 
     # Publish the crate to crates.io
-    DO rust+CARGO --secret CARGO_REGISTRY_TOKEN --args="cargo publish -v --all-features --token $CARGO_REGISTRY_TOKEN"
+    DO rust+CARGO --secret CARGO_REGISTRY_TOKEN --args="publish -v --all-features --token $CARGO_REGISTRY_TOKEN"
 
 TEST:
     FUNCTION


### PR DESCRIPTION
The target that publishes the crate had a bug that caused it to fail.