### PR TITLE
Restrict maximum dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ url = ["dep:url"]
 uuid = ["dep:uuid"]
 
 [dependencies]
-proc-macro2 = ">=1.0.63"
-quote = ">=1.0.28"
-secrecy = { version = ">=0.10.3", optional = true }
-serde = { version = ">=1.0.103", features = ["derive"], optional = true }
-syn = { version = ">=2.0.31", features = ["extra-traits"] }
-ulid = { version = ">=1.1.3", optional = true }
-url = { version = ">=2.2.0", optional = true }
-uuid = { version = ">=1.0.0", optional = true }
+proc-macro2 = ">=1.0.63, <2"
+quote = ">=1.0.28, <2"
+secrecy = { version = ">=0.10.3, <0.11", optional = true }
+serde = { version = ">=1.0.103, <2", features = ["derive"], optional = true }
+syn = { version = ">=2.0.31, <3", features = ["extra-traits"] }
+ulid = { version = ">=1.1.3, <2", optional = true }
+url = { version = ">=2.2.0, <3", optional = true }
+uuid = { version = ">=1.0.0, <2", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.0"


### PR DESCRIPTION
In conversation with @martijnarts and @benwis, we discussed how to both provide a wide range of dependency versions and still ensuring that breaking API are caught early. The best solution seems to be to define a lower bound and restrict the upper bound to the latest major version that has been tested against this crate. When future major versions of dependencies are released, typed-fields can be tested against them to ensure the crate supports them cleanly.