### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2025-05-14
+
+### Changed
+
+- Restrict maximum dependency versions
+
 ## [0.4.1] - 2025-03-20
 
 ### Added
@@ -53,6 +59,7 @@ and this project adheres to
 - Optionally derive serde traits
 - Create `secret!` macro for fields with secrets
 
+[0.4.2]: https://github.com/jdno/typed-fields/releases/tag/v0.4.2
 [0.4.1]: https://github.com/jdno/typed-fields/releases/tag/v0.4.1
 [0.4.0]: https://github.com/jdno/typed-fields/releases/tag/v0.4.0
 [0.3.0]: https://github.com/jdno/typed-fields/releases/tag/v0.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-fields"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
This release locks the maximum version of the crate's dependencies to prevent accidentally breaking builds when new major versions are released.