### PR TITLE
Fix passing Cargo token to Earthly target

### DIFF
--- a/.earthly/rust/Earthfile
+++ b/.earthly/rust/Earthfile
@@ -107,7 +107,7 @@ PUBLISH:
     COPY README.md .
 
     # Publish the crate to crates.io
-    DO rust+CARGO --secret CARGO_REGISTRY_TOKEN --args="publish -v --all-features --token $CARGO_REGISTRY_TOKEN"
+    RUN --secret CARGO_REGISTRY_TOKEN cargo publish -v --all-features --token $CARGO_REGISTRY_TOKEN
 
 TEST:
     FUNCTION


### PR DESCRIPTION
It seems that Earthly functions do not inherit access to secrets, requiring to pass them as arguments. To avoid this, the publish task is no longer calling a nested function but instead runs cargo directly.