### PR TITLE
Fix formatting of TOML files

### DIFF
--- a/.earthly/toml/Earthfile
+++ b/.earthly/toml/Earthfile
@@ -1,12 +1,19 @@
 VERSION 0.8
 
+taplo:
+    FROM tamasfe/taplo:latest
+    SAVE ARTIFACT /taplo
+
 FORMAT:
     FUNCTION
 
     ARG FIX="false"
 
-    FROM tamasfe/taplo:latest
+    FROM alpine:latest
     WORKDIR /typed-fields
+
+    # Copy the taplo binary into the container
+    COPY +taplo/taplo /usr/local/bin/taplo
 
     # Copy the source code into the container
     COPY . .


### PR DESCRIPTION
The latest Taplo containers do not contain a shell anymore, which breaks using them with Earthly. To work around this issue, the binary is now copied into an Alpine container.