### PR TITLE
Use trusted publishing on crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.8
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish with Earthly
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
-          EARTHLY_TOKEN: ${{ secrets.EARTHLY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: earthly --ci --push --remote-cache=ghcr.io/jdno/typed-fields-earthly-cache:publish-crate --secret CARGO_REGISTRY_TOKEN  +publish-crate


### PR DESCRIPTION
crates.io is adding [trusted publishing], which uses OIDC to generate a short-lived authentication token for crates.io to publish a crate.

[trusted publishing]: https://crates.io/docs/trusted-publishing