### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2025-07-04
+
+### Changed
+
+- Publish crate using trusted publishing
+
 ## [0.4.2] - 2025-05-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-fields"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
This is a maintenance release that switches to [trusted publishing] to get a short-lived token for crates.io

[trusted publishing]: https://crates.io/docs/trusted-publishing