### PR TITLE
Restore permissions for packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The release workflow also needs access to packages to store its cache.