### PR TITLE
Fix failing doctest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ pub fn uuid(input: TokenStream) -> TokenStream {
 /// name!(
 ///     /// This is a doc comment
 ///     TestName
-/// )
+/// );
 /// ```
 ///
 /// In this example, `attrs` will contain the doc comment and `ident` will


### PR DESCRIPTION
One of the doctests failed when being run outside of Earthly (for yet unknown reasons that we won't investigate further).