### PR TITLE
Fix recipe to publish crate

### DIFF
--- a/justfile
+++ b/justfile
@@ -101,7 +101,7 @@ prettier fix="false" extension="*":
 
 # Publish the crate to crates.io
 publish:
-    cargo publish--all-features --token $CARGO_REGISTRY_TOKEN
+    cargo publish --all-features --token $CARGO_REGISTRY_TOKEN
 
 # Run the tests
 test-rust:


### PR DESCRIPTION
The recipe to publish the crate was missing a space character, which broke the publishing action on GitHub.