### PR TITLE
Allow changing the type in `number!` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,23 +70,32 @@ pub fn name(input: TokenStream) -> TokenStream {
 
 /// Generate a new type for a number
 ///
-/// The `number!` macro generates a new type that is backed by an `i64`. The new type implements
-/// common traits like `Display` and `From<i64>`. The inner value can be accessed using the `get`
-/// method.
+/// The `number!` macro generates a new type that is backed by a numeric primitive. By default it
+/// uses `i64`, but you can optionally provide a different backing type, e.g. `u64`. The new type
+/// implements common traits like `Display` and `From<T>`, where `T` is the chosen backing type. The
+/// inner value can be accessed using the `get` method.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use typed_fields::number;
 ///
-/// // Define a new type that is backed by an `i64`
 /// number!(UserId);
 ///
-/// // Create a new `UserId` from an `i64`
 /// let id = UserId::new(42);
-///
-/// // Common traits like `Display` are automatically implemented for the type
 /// println!("User ID: {}", id);
+/// ```
+///
+/// The default backing type is `i64`, but this can be changed by passing another type as the second
+/// argument:
+///
+/// ```
+/// use typed_fields::number;
+///
+/// number!(Revision, u64);
+///
+/// let rev = Revision::new(42u64);
+/// assert_eq!(42u64, rev.get());
 /// ```
 #[proc_macro]
 pub fn number(input: TokenStream) -> TokenStream {

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,23 +1,51 @@
 use proc_macro::TokenStream;
 
 use quote::quote;
+use syn::parse::{Parse, ParseStream};
 use syn::parse_macro_input;
+use syn::{Attribute, Ident, Token, Type};
 
-use crate::Input;
+/// Input for the `number!` macro
+///
+/// Supports:
+/// - `number!(Ident)` → defaults to `i64`
+/// - `number!(Ident, BackingType)`
+struct NumberInput {
+    attrs: Vec<Attribute>,
+    ident: Ident,
+    ty: Option<Type>,
+}
+
+impl Parse for NumberInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let attrs = input.call(Attribute::parse_outer)?;
+        let ident: Ident = input.parse()?;
+
+        let ty = if input.peek(Token![,]) {
+            let _ = input.parse::<Token![,]>()?;
+            Some(input.parse::<Type>()?)
+        } else {
+            None
+        };
+
+        Ok(Self { attrs, ident, ty })
+    }
+}
 
 pub fn number_impl(input: TokenStream) -> TokenStream {
-    let Input { attrs, ident } = parse_macro_input!(input as Input);
+    let NumberInput { attrs, ident, ty } = parse_macro_input!(input as NumberInput);
     let derives = derives();
+    let backing_ty: Type = ty.unwrap_or_else(|| syn::parse_quote! { i64 });
 
     let newtype = quote! {
         #(#attrs)*
         #derives
-        pub struct #ident(i64);
+        pub struct #ident(#backing_ty);
 
         impl #ident {
             /// Create a new `#ident`
             ///
-            /// This method creates a new `#ident` from an `i64`.
+            /// This method creates a new `#ident` from a `#backing_ty`.
             ///
             /// # Example
             ///
@@ -28,14 +56,14 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
             ///
             /// let number = Number::new(42);
             /// ```
-            pub fn new(id: i64) -> Self {
+            pub fn new(id: #backing_ty) -> Self {
                 Self(id)
             }
 
             /// Get the inner value of the `#ident`
             ///
             /// This method returns a copy of the inner value of the `#ident`.
-            pub fn get(&self) -> i64 {
+            pub fn get(&self) -> #backing_ty {
                 self.0
             }
         }
@@ -46,8 +74,8 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
             }
         }
 
-        impl From<i64> for #ident {
-            fn from(id: i64) -> #ident {
+        impl From<#backing_ty> for #ident {
+            fn from(id: #backing_ty) -> #ident {
                 #ident(id)
             }
         }

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -8,6 +8,11 @@ number!(
     TestId
 );
 
+number!(
+    /// A `u64` backed number type
+    TestU64, u64
+);
+
 #[test]
 fn get() {
     let id = TestId::new(42);
@@ -32,6 +37,12 @@ fn compiles_in_sea_orm_model() {
     pub enum Relation {}
 
     impl ActiveModelBehavior for ActiveModel {}
+}
+
+#[test]
+fn u64() {
+    let id = TestU64::new(42u64);
+    assert_eq!(42u64, id.get());
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
The `number!` macro has been expanded to allow changing the backing type for newtypes that are created with it. The default is still an `i64`, but callers can change this based on the needs of their application.