### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2025-08-10
+
+### Added
+
+- Allow changing the type in `number!` macro
+
 ## [0.5.0] - 2025-08-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,7 +1967,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-fields"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
The type for the `number!` macro can now be changed by passing it as an optional second argument.