### PR TITLE
Remove the Flox installer in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@v2
 
+      - name: Remove Flox installer (if it exists)
+        run: rm -f flox.x86_64-linux.deb
+
       - name: Run check with Just
         uses: flox/activate-action@v1
         with:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@v2
 
+      - name: Remove Flox installer (if it exists)
+        run: rm -f flox.x86_64-linux.deb
+
       - name: Run tests with latest dependency versions
         uses: flox/activate-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install Flox
         uses: flox/install-flox-action@v2
 
+      - name: Remove Flox installer (if it exists)
+        run: rm -f flox.x86_64-linux.deb
+
       - name: Authenticate with crates.io
         id: auth
         uses: rust-lang/crates-io-auth-action@v1


### PR DESCRIPTION
The `flox/install-flox-action` currently downloads the Debian package into the current working directory. This is usually not a problem, but it leaves the Git repository in a dirty state which causes issues with `cargo publish`.