### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2025-08-11
+
+### Fixed
+
+- Fix feature flags leaking into generated code
+
 ## [0.5.1] - 2025-08-10
 
 ### Added
@@ -81,6 +87,8 @@ and this project adheres to
 - Optionally derive serde traits
 - Create `secret!` macro for fields with secrets
 
+[0.5.2]: https://github.com/jdno/typed-fields/releases/tag/v0.5.2
+[0.5.1]: https://github.com/jdno/typed-fields/releases/tag/v0.5.1
 [0.5.0]: https://github.com/jdno/typed-fields/releases/tag/v0.5.0
 [0.4.2]: https://github.com/jdno/typed-fields/releases/tag/v0.4.2
 [0.4.1]: https://github.com/jdno/typed-fields/releases/tag/v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "tests/krate"]
 
 [package]
 name = "typed-fields"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
This release fixed a bug that was introduced with the SeaORM integration, which caused feature flags of the `typed-fields` crate to leak into expanded code.