### PR TITLE
Log into ghcr.io before pushing devcontainer

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -20,6 +20,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pre-build devcontainer
         uses: devcontainers/ci@v0.3
         with:


### PR DESCRIPTION
The workflow that builds the devcontainer had access to the packages, but apparently needs to sign into ghcr.io to push the image.