### PR TITLE
Install vim in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
         python3 \
         python3-pip \
         rustup \
+        vim \
     && rm -rf /var/lib/apt/lists/*
 
 # Install global developer tools as root


### PR DESCRIPTION
The devcontainer did not include an editor yet, causing `git commit` to fail with an error.