### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-03-29
+
+### Fixed
+
+- Fix missing import in `uuid!` macro documentation
+
 ## [0.6.0] - 2025-12-03
 
 ### Added
@@ -93,6 +99,7 @@ and this project adheres to
 - Optionally derive serde traits
 - Create `secret!` macro for fields with secrets
 
+[0.6.1]: https://github.com/jdno/typed-fields/releases/tag/v0.6.1
 [0.6.0]: https://github.com/jdno/typed-fields/releases/tag/v0.6.0
 [0.5.2]: https://github.com/jdno/typed-fields/releases/tag/v0.5.2
 [0.5.1]: https://github.com/jdno/typed-fields/releases/tag/v0.5.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "tests/krate"]
 
 [package]
 name = "typed-fields"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
This release fixes a missing import in the auto-generated documentation for the `uuid!` macro.