### PR TITLE
Add configuration for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
+  "enabledPlugins": {
+    "simple-english@simple-english": true
+  },
+  "extraKnownMarketplaces": {
+    "simple-english": {
+      "source": {
+        "source": "github",
+        "repo": "AminBlg/SimpleEnglish"
+      }
+    }
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "filesystem": {
+      "allowWrite": [".flox/cache", ".flox/log", ".flox/run"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# typed-fields
+
+`typed-fields` is a collection of macros that generate types following the
+newtype pattern in Rust.
+
+## Language
+
+- Use American English spelling, e.g. "color" not "colour".
+
+## Markdown
+
+- Use title case in headings and titles.
+- Always use the Oxford comma.
+- Use reference-style Markdown links, not inline links.
+- Table cells must be single-line. Markdown does not support multi-line cells;
+  each newline starts a new row. Ignore line length limits for table rows.
+
+## Rust
+
+### Dependencies
+
+- Require the lowest version of a dependency that still compiles, so that
+  applications keep the widest choice of versions. Verify the floor with
+  `just check-minimal-deps`.
+- Write dependency entries without comments. Do not describe what a package
+  does, and do not explain a version requirement. Reasoning that matters, such
+  as why a floor cannot go lower, belongs in the commit message.
+
+### Derives
+
+- Standard trait order: Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash,
+  Debug, Default
+- Third-party derives: alphabetical by crate, then by macro.
+- First list traits from the standard library, then from external crates.
+
+### Documentation
+
+- Documentation should explain the "why", not just the "what".
+  - **Types**: Explain design decisions, invariants, and relationships to other
+    types.
+  - **Functions**: Document side effects, caller considerations, and non-obvious
+    behavior.
+  - **Modules**: Explain the module's role in the system and key concepts.
+- Write documentation for a reader that has no prior context, and especially no
+  knowledge of the conversation that led to the creation of the code.
+- Write for a consumer of the published crate. Internal rationale, such as which
+  library a function hides, stays out of the documentation as well. Document
+  what the API does, what it requires of the caller, and how it fails.
+- Write function/method docs in third-person singular
+  ("Returns the..." not "Return the...").
+- Do not add a trailing period on the title (i.e. the first line).
+- Use reference-style links in doc comments, not inline path links. Paths like
+  `super::` and `crate::` should not appear in rendered documentation.
+- Use the `/simple-english:simple-english` skill to adhere to the ASD-STE100
+  standard for Simplified Technical English.
+
+### Modules
+
+- One public type per module, use submodules for related types.
+- Use `mod.rs` for modules that contain submodules.
+- Prefer `pub` over `pub(crate)`. Visibility should come from module
+  structure, not access modifiers. If a type needs restricted visibility,
+  that is usually a signal to restructure the modules.
+
+### Tests
+
+- Use blank lines to separate Arrange/Act/Assert phases.
+- Test functions ordered alphabetically within modules.
+- Name tests descriptively: `function_name_<condition>_<result>`, e.g.
+  `greet_with_name_returns_greeting`.
+- Do not test compiler-derived traits (Eq, Ord, Hash, Clone, etc.). Only test
+  auto traits (Send, Sync, Unpin) and custom behavior like builder round-trips.
+- Each test should have exactly one assertion.
+
+### Type System
+
+- Use enums with meaningful variants instead of bool parameters.
+- Fields must never be `pub`. Implement getters instead.
+
+## Version Control
+
+- Never commit directly to `main`, always create a branch or worktree.
+- Every commit should be a logical unit of change.
+- Every commit must build and pass all checks. Use `just` recipes for
+  verification (e.g. `just pre-commit`).
+- Fixes and refactoring should be in separate commits from features.
+- Each pull request should have one primary commit with a well-crafted
+  message — this is what lands in the Git history. Follow-up fixups within
+  the same PR can use simple one-liner messages since they get squashed into
+  the primary commit on merge.
+- Because a pull request lands as a single commit, separate a fix or a
+  refactoring from a feature by opening separate pull requests, not by
+  adding commits to one.
+
+### Commit Messages
+
+- We use Git as our Version Control System and GitHub to host the code.
+- We use pre-commit hooks to verify the changes before committing them.
+- We follow this [style guide][git-style-guide] for commit messages:
+  - Capitalized, short (50 characters or less) summary in imperative mode
+    ("Fix bug", not "Fixed bug")
+  - Blank line between summary and body
+  - Focus on the "why" — motivation and reasoning — not what changed
+  - Minimal formatting or bullet points, plain prose is preferred
+  - Full sentences with simple past and present tense
+  - Wrap the body at 72 characters
+- Write commit messages for a reader that has no prior context and no access to
+  the session history.
+- Keep commit messages concise. Aim for two or three paragraphs, not more.
+- Don't use backticks in commit message titles, but do use them in bodies.
+- **Never** write conventional commit messages.
+- **Never** add yourself as a co-author.
+
+[git-style-guide]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- markdownlint-disable-file MD041 -->
+
+@AGENTS.md


### PR DESCRIPTION
Coding agents need the same context a new contributor does: the conventions this project follows, and the reasoning behind them. `AGENTS.md` collects those conventions so that generated code matches the existing style instead of a generic one, and `CLAUDE.md` points at it so that a single file remains the source of truth for every agent.

## Changes

- `AGENTS.md` with the conventions for language, Markdown, Rust and version control
- `CLAUDE.md`, which imports `AGENTS.md`
- `.claude/settings.json`, which disables the attribution that Claude Code adds to commits and pull requests by default, enables the sandbox, and permits writes to the Flox directories the `just` recipes need

## Notes for review

The conventions describe where the project is going rather than where it is. Three things diverge from them today, and each is corrected in its own pull request rather than here:

| Divergence | Extent |
|---|---|
| Documentation voice | 21 imperative summaries, 0 third-person |
| Test names | Roughly 70 tests use `trait_*` rather than `function_name_<condition>_<result>` |
| Test ordering | 6 of 7 test files are not alphabetical; `tests/secret.rs` already is |

On documentation voice, the rule matches the wider ecosystem rather than inventing a house style. RFC 1574 asks for the third person singular present indicative, and the standard library follows it 2911 times against 35 imperative summaries. Note that the affected summaries are generated into every consumer's crate, so correcting them changes published documentation for downstream users. It is documentation only, so nothing breaks.

On test names, the pattern in the rule does not map cleanly onto tests such as `trait_send` and `trait_unpin`, which assert that a bound holds rather than exercising a function. That pull request should refine the rule to cover both shapes rather than force those tests into a condition and result.

`CLAUDE.md` carries a `markdownlint-disable-file MD041` comment because `@AGENTS.md` is not a top-level heading and `just lint-markdown` would otherwise fail. This follows the precedent in `CHANGELOG.md`. Adding the file to `.markdownlintignore` would not have worked, since the recipe passes `--ignore-path .gitignore` and never consults it.

`just pre-commit` passes.