### PR TITLE
Fix the documentation of generated types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod url;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-/// Generate a new type for a string
+/// Generates a new type for a string
 ///
 /// The `name!` macro generates a new type that is backed by a `String`. The new type implements
 /// common traits like `Display` and `From<&str>` and `From<String>`. The inner value can be
@@ -69,7 +69,7 @@ pub fn name(input: TokenStream) -> TokenStream {
     name::name_impl(input)
 }
 
-/// Generate a new type for a number
+/// Generates a new type for a number
 ///
 /// The `number!` macro generates a new type that is backed by a numeric primitive. By default it
 /// uses `i64`, but you can optionally provide a different backing type, e.g. `u64`. The new type
@@ -103,7 +103,7 @@ pub fn number(input: TokenStream) -> TokenStream {
     number::number_impl(input)
 }
 
-/// Generate a new type for a path
+/// Generates a new type for a path
 ///
 /// The `path!` macro generates a new type that is backed by a `PathBuf`. The new type implements
 /// common traits like `Display` and `From<&Path>`. The inner value can be accessed using the
@@ -125,7 +125,7 @@ pub fn path(input: TokenStream) -> TokenStream {
     path::path_impl(input)
 }
 
-/// Generate a new type for a secret
+/// Generates a new type for a secret
 ///
 /// The `secret!` macro generates a new type for secrets such as passwords and API tokens. The type
 /// uses the [`secrecy`](https://crates.io/crates/secrecy) crate internally to prevent accidentally
@@ -150,7 +150,7 @@ pub fn secret(input: TokenStream) -> TokenStream {
     secret::secret_impl(input)
 }
 
-/// Generate a new type for a ULID
+/// Generates a new type for a ULID
 ///
 /// The `ulid!` macro generates a new type that is backed by a `Ulid` from the [`ulid`] crate. The
 /// new type implements common traits like `Display` and `From<&str>` and `From<String>`. The inner
@@ -177,7 +177,7 @@ pub fn ulid(input: TokenStream) -> TokenStream {
     ulid::ulid_impl(input)
 }
 
-/// Generate a new type for a URL
+/// Generates a new type for a URL
 ///
 /// The `url!` macro generates a new type that is backed by a `Url` from the [`url`] crate. The new
 /// type implements common traits like `Display` and `TryFrom<&str>` and `TryFrom<String>`. The
@@ -204,7 +204,7 @@ pub fn url(input: TokenStream) -> TokenStream {
     url::url_impl(input)
 }
 
-/// Generate a new type for a UUID
+/// Generates a new type for a UUID
 ///
 /// The `uuid!` macro generates a new type that is backed by a `Uuid` from the [`uuid`] crate. The
 /// new type implements common traits like `Display` and `TryFrom<&str>` and `TryFrom<String>`. The

--- a/src/name.rs
+++ b/src/name.rs
@@ -9,17 +9,26 @@ pub fn name_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from anything that implements the \
+         `Into<String>` trait. This includes `&str`, `String`, and other types \
+         that can be converted into a `String`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a reference to the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(String);
 
         impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from anything that implements
-            /// the `Into<String>` trait. This includes `&str`, `String`, and
-            /// other types that can be converted into a `String`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -34,10 +43,7 @@ pub fn name_impl(input: TokenStream) -> TokenStream {
                 Self(name.into())
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a reference to the inner value of the
-            /// `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> &str {
                 &self.0
             }

--- a/src/number.rs
+++ b/src/number.rs
@@ -37,15 +37,25 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
     let derives = derives();
     let backing_ty: Type = ty.unwrap_or_else(|| syn::parse_quote! { i64 });
 
+    let backing_ty_name = quote! { #backing_ty }.to_string();
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `{backing_ty_name}`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a copy of the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(#backing_ty);
 
         impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `#backing_ty`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -60,9 +70,7 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
                 Self(id)
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a copy of the inner value of the `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> #backing_ty {
                 self.0
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -8,15 +8,24 @@ pub fn path_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `PathBuf`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a reference to the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(std::path::PathBuf);
 
         impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `PathBuf`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -32,10 +41,7 @@ pub fn path_impl(input: TokenStream) -> TokenStream {
                 Self(path.into())
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a reference to the inner value of the
-            /// `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> &std::path::Path {
                 &self.0
             }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -9,15 +9,24 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `&str`."
+    );
+    let expose_doc = format!(
+        "Exposes the secret's inner value\n\
+         \n\
+         This method returns a reference to the exposed value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(secrecy::SecretString);
 
         impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `&str`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -32,10 +41,7 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
                 Self(String::from(secret).into())
             }
 
-            /// Expose the secret's inner value
-            ///
-            /// This method returns a reference to the exposed value of the
-            /// `#ident`.
+            #[doc = #expose_doc]
             pub fn expose(&self) -> &str {
                 use secrecy::ExposeSecret;
                 self.0.expose_secret()

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -9,15 +9,24 @@ pub fn ulid_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `Ulid`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a reference to the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(ulid::Ulid);
 
          impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `Ulid`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -33,10 +42,7 @@ pub fn ulid_impl(input: TokenStream) -> TokenStream {
                 Self(ulid)
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a reference to the inner value of the
-            /// `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> &ulid::Ulid {
                 &self.0
             }

--- a/src/url.rs
+++ b/src/url.rs
@@ -9,15 +9,24 @@ pub fn url_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `URL`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a reference to the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(url::Url);
 
          impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `URL`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -33,10 +42,7 @@ pub fn url_impl(input: TokenStream) -> TokenStream {
                 Self(url)
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a reference to the inner value of the
-            /// `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> &url::Url {
                 &self.0
             }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -9,15 +9,24 @@ pub fn uuid_impl(input: TokenStream) -> TokenStream {
     let Input { attrs, ident } = parse_macro_input!(input as Input);
     let derives = derives();
 
+    let new_doc = format!(
+        "Creates a new `{ident}`\n\
+         \n\
+         This method creates a new `{ident}` from a `Uuid`."
+    );
+    let get_doc = format!(
+        "Gets the inner value of the `{ident}`\n\
+         \n\
+         This method returns a reference to the inner value of the `{ident}`."
+    );
+
     let newtype = quote! {
         #(#attrs)*
         #derives
         pub struct #ident(uuid::Uuid);
 
          impl #ident {
-            /// Create a new `#ident`
-            ///
-            /// This method creates a new `#ident` from a `Uuid`.
+            #[doc = #new_doc]
             ///
             /// # Example
             ///
@@ -33,10 +42,7 @@ pub fn uuid_impl(input: TokenStream) -> TokenStream {
                 Self(uuid)
             }
 
-            /// Get the inner value of the `#ident`
-            ///
-            /// This method returns a reference to the inner value of the
-            /// `#ident`.
+            #[doc = #get_doc]
             pub fn get(&self) -> &uuid::Uuid {
                 &self.0
             }


### PR DESCRIPTION
The documentation that the macros generate never named the type it described. `quote!` does not interpolate variables inside a doc comment, so `#ident` reached the published documentation verbatim. A consumer who wrote `name!(Login)` read this on `Login::new`:

> Create a new `#ident`
>
> This method creates a new `#ident` from anything that implements the `Into<String>` trait.

The `number!` macro leaked `#backing_ty` the same way. Building the text with `format!` and passing it through `#[doc]` interpolates the names as intended, so the same method now reads:

> Creates a new `Login`
>
> This method creates a new `Login` from anything that implements the `Into<String>` trait.

## Documentation voice

The summaries also used the imperative mood, which `AGENTS.md` asks against. That rule is not a house style: RFC 1574 asks for the third person singular present indicative, and the standard library follows it 1729 times for `Returns` alone, against 35 imperative summaries across `core`, `alloc` and `std`. All 21 summaries in this crate were imperative and none were third person.

`Get` became `Gets` rather than `Returns`, to keep this a change of voice rather than a rewording. Both are attested in the standard library, `Gets` 182 times.

## Notes for review

- Verified by building rustdoc for a crate that calls `name!(Login)` and `number!(Revision, u32)`, then reading the rendered HTML. The summaries render as `Creates a new Login` and `Gets the inner value of the Revision`, and the body of `Revision::new` correctly names `u32`.
- The examples in the doc comments stay literal `///` comments. They use a fixed type name and do not depend on the caller, so they need no interpolation, and keeping them as comments keeps the doctests readable.
- This changes the documentation that downstream crates publish, including their doctest output. There are no API changes, so nothing that compiles today stops compiling.
- `just pre-commit` and `just build-docs` both pass.