### PR TITLE
Rename and reorder the tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,11 @@ newtype pattern in Rust.
 - Use blank lines to separate Arrange/Act/Assert phases.
 - Test functions ordered alphabetically within modules.
 - Name tests descriptively: `function_name_<condition>_<result>`, e.g.
-  `greet_with_name_returns_greeting`.
+  `greet_with_name_returns_greeting`. Leave out the condition when a function
+  has only one case, e.g. `get_returns_inner_value`.
+- Name a test that only asserts a trait bound `implements_<trait>`, e.g.
+  `implements_send`. Such a test has no condition and no result, because it
+  asserts that a bound holds rather than exercising a function.
 - Do not test compiler-derived traits (Eq, Ord, Hash, Clone, etc.). Only test
   auto traits (Send, Sync, Unpin) and custom behavior like builder round-trips.
 - Each test should have exactly one assertion.

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -8,16 +8,9 @@ name!(
     TestName
 );
 
-#[test]
-fn get() {
-    let name = TestName::new("test");
-
-    assert_eq!("test", name.get());
-}
-
 #[cfg(feature = "serde")]
 #[test]
-fn trait_deserialize() {
+fn deserialize_returns_name() {
     let json = r#""test""#;
 
     let name: TestName = serde_json::from_str(json).unwrap();
@@ -26,46 +19,53 @@ fn trait_deserialize() {
 }
 
 #[test]
-fn trait_display() {
+fn display_returns_inner_value() {
     let name = TestName::new("test");
 
     assert_eq!("test", name.to_string());
 }
 
 #[test]
-fn trait_from_string() {
-    let _name: TestName = String::from("test").into();
-}
-
-#[test]
-fn trait_from_str() {
+fn from_str_returns_name() {
     let _name: TestName = "test".into();
 }
 
 #[test]
-fn trait_send() {
+fn from_string_returns_name() {
+    let _name: TestName = String::from("test").into();
+}
+
+#[test]
+fn get_returns_inner_value() {
+    let name = TestName::new("test");
+
+    assert_eq!("test", name.get());
+}
+
+#[test]
+fn implements_send() {
     fn assert_send<T: Send>() {}
     assert_send::<TestName>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
-fn trait_serialize() {
-    let name = TestName::new("test");
-
-    let json = serde_json::to_string(&name).unwrap();
-
-    assert_eq!(r#""test""#, json);
-}
-
-#[test]
-fn trait_sync() {
+fn implements_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<TestName>();
 }
 
 #[test]
-fn trait_unpin() {
+fn implements_unpin() {
     fn assert_unpin<T: Unpin>() {}
     assert_unpin::<TestName>();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serialize_returns_json() {
+    let name = TestName::new("test");
+
+    let json = serde_json::to_string(&name).unwrap();
+
+    assert_eq!(r#""test""#, json);
 }

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -13,22 +13,9 @@ number!(
     TestU64, u64
 );
 
-#[test]
-fn get() {
-    let id = TestId::new(42);
-
-    assert_eq!(42, id.get());
-}
-
-#[test]
-fn u64() {
-    let id = TestU64::new(42u64);
-    assert_eq!(42u64, id.get());
-}
-
 #[cfg(feature = "serde")]
 #[test]
-fn trait_deserialize() {
+fn deserialize_returns_number() {
     let json = "42";
 
     let id: TestId = serde_json::from_str(json).unwrap();
@@ -37,41 +24,54 @@ fn trait_deserialize() {
 }
 
 #[test]
-fn trait_display() {
+fn display_returns_inner_value() {
     let id = TestId::new(42);
 
     assert_eq!("42", id.to_string());
 }
 
 #[test]
-fn trait_from_i64() {
+fn from_i64_returns_number() {
     let _id: TestId = 42.into();
 }
 
 #[test]
-fn trait_send() {
+fn get_returns_inner_value() {
+    let id = TestId::new(42);
+
+    assert_eq!(42, id.get());
+}
+
+#[test]
+fn get_with_u64_backing_type_returns_value() {
+    let id = TestU64::new(42u64);
+    assert_eq!(42u64, id.get());
+}
+
+#[test]
+fn implements_send() {
     fn assert_send<T: Send>() {}
     assert_send::<TestId>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
-fn trait_serialize() {
-    let id = TestId::new(42);
-
-    let json = serde_json::to_string(&id).unwrap();
-
-    assert_eq!("42", json);
-}
-
-#[test]
-fn trait_sync() {
+fn implements_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<TestId>();
 }
 
 #[test]
-fn trait_unpin() {
+fn implements_unpin() {
     fn assert_unpin<T: Unpin>() {}
     assert_unpin::<TestId>();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serialize_returns_json() {
+    let id = TestId::new(42);
+
+    let json = serde_json::to_string(&id).unwrap();
+
+    assert_eq!("42", json);
 }

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -10,16 +10,9 @@ path!(
     TestPath
 );
 
-#[test]
-fn get() {
-    let path = TestPath::new("test".into());
-
-    assert_eq!(Path::new("test"), path.get());
-}
-
 #[cfg(feature = "serde")]
 #[test]
-fn trait_deserialize() {
+fn deserialize_returns_path() {
     let json = r#""test""#;
 
     let path: TestPath = serde_json::from_str(json).unwrap();
@@ -28,46 +21,53 @@ fn trait_deserialize() {
 }
 
 #[test]
-fn trait_display() {
+fn display_returns_inner_value() {
     let path = TestPath::new("test".into());
 
     assert_eq!("test", path.to_string());
 }
 
 #[test]
-fn trait_from_string() {
-    let _path: TestPath = String::from("test").into();
-}
-
-#[test]
-fn trait_from_str() {
+fn from_str_returns_path() {
     let _path: TestPath = "test".into();
 }
 
 #[test]
-fn trait_send() {
+fn from_string_returns_path() {
+    let _path: TestPath = String::from("test").into();
+}
+
+#[test]
+fn get_returns_inner_value() {
+    let path = TestPath::new("test".into());
+
+    assert_eq!(Path::new("test"), path.get());
+}
+
+#[test]
+fn implements_send() {
     fn assert_send<T: Send>() {}
     assert_send::<TestPath>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
-fn trait_serialize() {
-    let name: TestPath = "test".into();
-
-    let json = serde_json::to_string(&name).unwrap();
-
-    assert_eq!(r#""test""#, json);
-}
-
-#[test]
-fn trait_sync() {
+fn implements_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<TestPath>();
 }
 
 #[test]
-fn trait_unpin() {
+fn implements_unpin() {
     fn assert_unpin<T: Unpin>() {}
     assert_unpin::<TestPath>();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn serialize_returns_json() {
+    let name: TestPath = "test".into();
+
+    let json = serde_json::to_string(&name).unwrap();
+
+    assert_eq!(r#""test""#, json);
 }

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -1,6 +1,24 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
+#[cfg(all(feature = "secret", feature = "serde"))]
+#[test]
+fn deserialize_returns_secret() {
+    let json = r#""test""#;
+
+    let config: TestSecret = serde_json::from_str(json).unwrap();
+
+    assert_eq!("test", config.expose());
+}
+
+#[cfg(feature = "secret")]
+#[test]
+fn display_returns_redacted_value() {
+    let secret = TestSecret::new("test");
+
+    assert_eq!("[REDACTED]", secret.to_string());
+}
+
 #[cfg(feature = "secret")]
 use typed_fields::secret;
 
@@ -12,59 +30,41 @@ secret!(
 
 #[cfg(feature = "secret")]
 #[test]
-fn expose() {
+fn expose_returns_secret() {
     let secret = TestSecret::new("test");
 
     assert_eq!("test", secret.expose());
 }
 
-#[cfg(all(feature = "secret", feature = "serde"))]
-#[test]
-fn trait_deserialize() {
-    let json = r#""test""#;
-
-    let config: TestSecret = serde_json::from_str(json).unwrap();
-
-    assert_eq!("test", config.expose());
-}
-
 #[cfg(feature = "secret")]
 #[test]
-fn trait_display() {
-    let secret = TestSecret::new("test");
-
-    assert_eq!("[REDACTED]", secret.to_string());
-}
-
-#[cfg(feature = "secret")]
-#[test]
-fn trait_from_str() {
+fn from_str_returns_secret() {
     let _secret: TestSecret = "test".into();
 }
 
 #[cfg(feature = "secret")]
 #[test]
-fn trait_from_string() {
+fn from_string_returns_secret() {
     let _secret: TestSecret = "test".into();
 }
 
 #[cfg(feature = "secret")]
 #[test]
-fn trait_send() {
+fn implements_send() {
     fn assert_send<T: Send>() {}
     assert_send::<TestSecret>();
 }
 
 #[cfg(feature = "secret")]
 #[test]
-fn trait_sync() {
+fn implements_sync() {
     fn assert_sync<T: Sync>() {}
     assert_sync::<TestSecret>();
 }
 
 #[cfg(feature = "secret")]
 #[test]
-fn trait_unpin() {
+fn implements_unpin() {
     fn assert_unpin<T: Unpin>() {}
     assert_unpin::<TestSecret>();
 }

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -1,6 +1,24 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
+#[cfg(all(feature = "serde", feature = "ulid"))]
+#[test]
+fn deserialize_returns_ulid() {
+    let json = r#""01ARZ3NDEKTSV4RRFFQ69G5FAV""#;
+
+    let ulid: TestUlid = serde_json::from_str(json).unwrap();
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+}
+
+#[cfg(feature = "ulid")]
+#[test]
+fn display_returns_inner_value() {
+    let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+}
+
 #[cfg(feature = "ulid")]
 use std::convert::TryInto;
 #[cfg(feature = "ulid")]
@@ -16,7 +34,7 @@ ulid!(
 
 #[cfg(feature = "ulid")]
 #[test]
-fn get() {
+fn get_returns_inner_value() {
     let input = Ulid::new();
 
     let ulid = TestUlid::new(input);
@@ -24,27 +42,30 @@ fn get() {
     assert_eq!(input, *ulid.get());
 }
 
-#[cfg(all(feature = "serde", feature = "ulid"))]
+#[cfg(feature = "ulid")]
 #[test]
-fn trait_deserialize() {
-    let json = r#""01ARZ3NDEKTSV4RRFFQ69G5FAV""#;
-
-    let ulid: TestUlid = serde_json::from_str(json).unwrap();
-
-    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+fn implements_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUlid>();
 }
 
 #[cfg(feature = "ulid")]
 #[test]
-fn trait_display() {
-    let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());
+fn implements_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUlid>();
+}
 
-    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
+#[cfg(feature = "ulid")]
+#[test]
+fn implements_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUlid>();
 }
 
 #[cfg(all(feature = "serde", feature = "ulid"))]
 #[test]
-fn trait_serialize() {
+fn serialize_returns_json() {
     let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());
 
     let json = serde_json::to_string(&ulid).unwrap();
@@ -54,13 +75,13 @@ fn trait_serialize() {
 
 #[cfg(feature = "ulid")]
 #[test]
-fn trait_try_from_str() {
+fn try_from_str_returns_ulid() {
     let _ulid: TestUlid = "01ARZ3NDEKTSV4RRFFQ69G5FAV".try_into().unwrap();
 }
 
 #[cfg(feature = "ulid")]
 #[test]
-fn trait_try_from_str_with_random_string() {
+fn try_from_str_with_invalid_input_returns_error() {
     let ulid = TestUlid::try_from("test");
 
     assert!(ulid.is_err());
@@ -68,7 +89,7 @@ fn trait_try_from_str_with_random_string() {
 
 #[cfg(feature = "ulid")]
 #[test]
-fn trait_try_from_string() {
+fn try_from_string_returns_ulid() {
     let _ulid: TestUlid = String::from("01ARZ3NDEKTSV4RRFFQ69G5FAV")
         .try_into()
         .unwrap();
@@ -76,29 +97,8 @@ fn trait_try_from_string() {
 
 #[cfg(feature = "ulid")]
 #[test]
-fn trait_try_from_string_with_random_string() {
+fn try_from_string_with_invalid_input_returns_error() {
     let ulid = TestUlid::try_from(String::from("test"));
 
     assert!(ulid.is_err());
-}
-
-#[cfg(feature = "ulid")]
-#[test]
-fn trait_send() {
-    fn assert_send<T: Send>() {}
-    assert_send::<TestUlid>();
-}
-
-#[cfg(feature = "ulid")]
-#[test]
-fn trait_sync() {
-    fn assert_sync<T: Sync>() {}
-    assert_sync::<TestUlid>();
-}
-
-#[cfg(feature = "ulid")]
-#[test]
-fn trait_unpin() {
-    fn assert_unpin<T: Unpin>() {}
-    assert_unpin::<TestUlid>();
 }

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,6 +1,24 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
+#[cfg(all(feature = "serde", feature = "url"))]
+#[test]
+fn deserialize_returns_url() {
+    let json = r#""postgres://localhost:5432/postgres""#;
+
+    let url: TestUrl = serde_json::from_str(json).unwrap();
+
+    assert_eq!("postgres://localhost:5432/postgres", url.to_string());
+}
+
+#[cfg(feature = "url")]
+#[test]
+fn display_returns_inner_value() {
+    let url = TestUrl::new(Url::parse("https://example.com").unwrap());
+
+    assert_eq!("https://example.com/", url.to_string());
+}
+
 #[cfg(feature = "url")]
 use std::convert::TryInto;
 
@@ -18,7 +36,7 @@ url!(
 
 #[cfg(feature = "url")]
 #[test]
-fn get() {
+fn get_returns_inner_value() {
     let input = Url::parse("postgres://localhost:5432/postgres").unwrap();
 
     let url = TestUrl::new(input.clone());
@@ -26,27 +44,30 @@ fn get() {
     assert_eq!(&input, url.get());
 }
 
-#[cfg(all(feature = "serde", feature = "url"))]
+#[cfg(feature = "url")]
 #[test]
-fn trait_deserialize() {
-    let json = r#""postgres://localhost:5432/postgres""#;
-
-    let url: TestUrl = serde_json::from_str(json).unwrap();
-
-    assert_eq!("postgres://localhost:5432/postgres", url.to_string());
+fn implements_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUrl>();
 }
 
 #[cfg(feature = "url")]
 #[test]
-fn trait_display() {
-    let url = TestUrl::new(Url::parse("https://example.com").unwrap());
+fn implements_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUrl>();
+}
 
-    assert_eq!("https://example.com/", url.to_string());
+#[cfg(feature = "url")]
+#[test]
+fn implements_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUrl>();
 }
 
 #[cfg(all(feature = "serde", feature = "url"))]
 #[test]
-fn trait_serialize() {
+fn serialize_returns_json() {
     let url = TestUrl::new(Url::parse("https://example.com").unwrap());
 
     let json = serde_json::to_string(&url).unwrap();
@@ -56,13 +77,13 @@ fn trait_serialize() {
 
 #[cfg(feature = "url")]
 #[test]
-fn trait_try_from_str() {
+fn try_from_str_returns_url() {
     let _url: TestUrl = "https://example.com/".try_into().unwrap();
 }
 
 #[cfg(feature = "url")]
 #[test]
-fn trait_try_from_str_with_random_string() {
+fn try_from_str_with_invalid_input_returns_error() {
     let url = TestUrl::try_from("test");
 
     assert!(url.is_err());
@@ -70,7 +91,7 @@ fn trait_try_from_str_with_random_string() {
 
 #[cfg(feature = "url")]
 #[test]
-fn trait_try_from_string() {
+fn try_from_string_returns_url() {
     let _url: TestUrl = String::from("postgres://user:password@locahost:5432/postgres")
         .try_into()
         .unwrap();
@@ -78,29 +99,8 @@ fn trait_try_from_string() {
 
 #[cfg(feature = "url")]
 #[test]
-fn trait_try_from_string_with_random_string() {
+fn try_from_string_with_invalid_input_returns_error() {
     let url = TestUrl::try_from(String::from("test"));
 
     assert!(url.is_err());
-}
-
-#[cfg(feature = "url")]
-#[test]
-fn trait_send() {
-    fn assert_send<T: Send>() {}
-    assert_send::<TestUrl>();
-}
-
-#[cfg(feature = "url")]
-#[test]
-fn trait_sync() {
-    fn assert_sync<T: Sync>() {}
-    assert_sync::<TestUrl>();
-}
-
-#[cfg(feature = "url")]
-#[test]
-fn trait_unpin() {
-    fn assert_unpin<T: Unpin>() {}
-    assert_unpin::<TestUrl>();
 }

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -1,6 +1,24 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
+#[cfg(all(feature = "serde", feature = "uuid"))]
+#[test]
+fn deserialize_returns_uuid() {
+    let json = r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#;
+
+    let uuid: TestUuid = serde_json::from_str(json).unwrap();
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn display_returns_inner_value() {
+    let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+}
+
 #[cfg(feature = "uuid")]
 use std::convert::TryInto;
 
@@ -17,7 +35,7 @@ uuid!(
 
 #[cfg(feature = "uuid")]
 #[test]
-fn get() {
+fn get_returns_inner_value() {
     let input = uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8");
 
     let uuid = TestUuid::new(input);
@@ -25,27 +43,30 @@ fn get() {
     assert_eq!(input, *uuid.get());
 }
 
-#[cfg(all(feature = "serde", feature = "uuid"))]
+#[cfg(feature = "uuid")]
 #[test]
-fn trait_deserialize() {
-    let json = r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#;
-
-    let uuid: TestUuid = serde_json::from_str(json).unwrap();
-
-    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+fn implements_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<TestUuid>();
 }
 
 #[cfg(feature = "uuid")]
 #[test]
-fn trait_display() {
-    let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
+fn implements_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<TestUuid>();
+}
 
-    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
+#[cfg(feature = "uuid")]
+#[test]
+fn implements_unpin() {
+    fn assert_unpin<T: Unpin>() {}
+    assert_unpin::<TestUuid>();
 }
 
 #[cfg(all(feature = "serde", feature = "uuid"))]
 #[test]
-fn trait_serialize() {
+fn serialize_returns_json() {
     let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));
 
     let json = serde_json::to_string(&uuid).unwrap();
@@ -55,13 +76,13 @@ fn trait_serialize() {
 
 #[cfg(feature = "uuid")]
 #[test]
-fn trait_try_from_str() {
+fn try_from_str_returns_uuid() {
     let _uuid: TestUuid = "67e55044-10b1-426f-9247-bb680e5fe0c8".try_into().unwrap();
 }
 
 #[cfg(feature = "uuid")]
 #[test]
-fn trait_try_from_str_with_random_string() {
+fn try_from_str_with_invalid_input_returns_error() {
     let uuid = TestUuid::try_from("test");
 
     assert!(uuid.is_err());
@@ -69,7 +90,7 @@ fn trait_try_from_str_with_random_string() {
 
 #[cfg(feature = "uuid")]
 #[test]
-fn trait_try_from_string() {
+fn try_from_string_returns_uuid() {
     let _uuid: TestUuid = String::from("67e55044-10b1-426f-9247-bb680e5fe0c8")
         .try_into()
         .unwrap();
@@ -77,29 +98,8 @@ fn trait_try_from_string() {
 
 #[cfg(feature = "uuid")]
 #[test]
-fn trait_try_from_string_with_random_string() {
+fn try_from_string_with_invalid_input_returns_error() {
     let uuid = TestUuid::try_from(String::from("test"));
 
     assert!(uuid.is_err());
-}
-
-#[cfg(feature = "uuid")]
-#[test]
-fn trait_send() {
-    fn assert_send<T: Send>() {}
-    assert_send::<TestUuid>();
-}
-
-#[cfg(feature = "uuid")]
-#[test]
-fn trait_sync() {
-    fn assert_sync<T: Sync>() {}
-    assert_sync::<TestUuid>();
-}
-
-#[cfg(feature = "uuid")]
-#[test]
-fn trait_unpin() {
-    fn assert_unpin<T: Unpin>() {}
-    assert_unpin::<TestUuid>();
 }


### PR DESCRIPTION
The test suite predates the conventions in `AGENTS.md` and did not follow them. Names such as `trait_display` and `get` described the item under test but not what the test expects of it, and only `tests/secret.rs` listed its tests alphabetically. Both make a suite harder to read as it grows, because a reader cannot tell from a failing test name what broke.

## Naming

| Before | After |
|---|---|
| `get` | `get_returns_inner_value` |
| `expose` | `expose_returns_secret` |
| `u64` | `get_with_u64_backing_type_returns_value` |
| `trait_display` | `display_returns_inner_value`, or `display_returns_redacted_value` for secrets |
| `trait_serialize` | `serialize_returns_json` |
| `trait_deserialize` | `deserialize_returns_url`, and so on per type |
| `trait_try_from_str_with_random_string` | `try_from_str_with_invalid_input_returns_error` |
| `trait_send`, `trait_sync`, `trait_unpin` | `implements_send`, `implements_sync`, `implements_unpin` |

## A gap in the convention

Renaming exposed a case the convention did not cover. A test such as `trait_send` asserts that a bound holds rather than exercising a function, so it has neither a condition nor a result and cannot take the prescribed `function_name_<condition>_<result>` shape. This pull request names those `implements_<trait>` and updates `AGENTS.md` to describe both shapes, along with the case where a function has only one condition and the condition is therefore left out.

## Notes for review

- No test changed what it asserts. The suite still holds 68 tests, and the count per file is unchanged.
- All seven files are now alphabetical.
- `just pre-commit` passes.

Two things I noticed but deliberately left alone, since they change what the tests verify rather than what they are called:

- `from_str_returns_name` and `from_string_returns_name` assert nothing. They bind the result to `_name` and so only prove that the conversion compiles, which conflicts with the rule that each test has exactly one assertion.
- In `tests/secret.rs`, the test now called `from_string_returns_secret` converts from a `&str` rather than a `String`, so it duplicates `from_str_returns_secret` and leaves `From<String>` untested.

Both look worth a follow-up.