### PR TITLE
Remove support for serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,27 +22,25 @@ proc-macro = true
 all-features = true
 
 [features]
-secret = ["dep:secrecy"]
-serde = [
-  "dep:serde",
-  "secrecy?/serde",
-  "ulid?/serde",
-  "url?/serde",
-  "uuid?/serde",
-]
-ulid = ["dep:ulid"]
-url = ["dep:url"]
-uuid = ["dep:uuid"]
+# These features only control which macros this crate exports. They never change
+# the code that an existing macro generates, so enabling one anywhere in the
+# dependency graph cannot affect another crate that shares this instance.
+secret = []
+ulid = []
+url = []
+uuid = []
 
 [dependencies]
 proc-macro2 = ">=1.0.63, <2"
 quote = ">=1.0.28, <2"
-secrecy = { version = ">=0.10.3, <0.11", optional = true }
-serde = { version = ">=1.0.184, <2", features = ["derive"], optional = true }
 syn = { version = ">=2.0.31, <3", features = ["extra-traits"] }
-ulid = { version = ">=1.1.3, <2", optional = true }
-url = { version = ">=2.2.2, <3", optional = true }
-uuid = { version = ">=1.1.2, <2", optional = true }
 
+# The tests consume this crate the way any other crate does, so they declare the
+# same dependencies a consumer declares. None of these are needed by the macros.
 [dev-dependencies]
+secrecy = { version = "0.10.3", features = ["serde"] }
+serde = { version = "1.0.184", features = ["derive"] }
 serde_json = "1.0.85"
+ulid = { version = "1.1.3", features = ["serde"] }
+url = { version = "2.2.2", features = ["serde"] }
+uuid = { version = "1.1.2", features = ["serde"] }

--- a/justfile
+++ b/justfile
@@ -21,6 +21,10 @@ pre-commit:
 build-docs:
     cargo doc --all-features --no-deps
 
+# Check that no feature leaks into a crate that did not enable it
+check-feature-unification:
+    cargo check --workspace --all-features
+
 # Check that all Cargo features compile
 check-features:
     cargo hack --feature-powerset check --lib --tests

--- a/src/name.rs
+++ b/src/name.rs
@@ -72,23 +72,7 @@ pub fn name_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -93,23 +93,7 @@ pub fn number_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -76,23 +76,7 @@ pub fn path_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/secret.rs
+++ b/src/secret.rs
@@ -78,23 +78,7 @@ pub fn secret_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize)]
+        #[derive(Clone, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/ulid.rs
+++ b/src/ulid.rs
@@ -81,23 +81,7 @@ pub fn ulid_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/url.rs
+++ b/src/url.rs
@@ -81,23 +81,7 @@ pub fn url_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/src/uuid.rs
+++ b/src/uuid.rs
@@ -81,23 +81,7 @@ pub fn uuid_impl(input: TokenStream) -> TokenStream {
 }
 
 fn derives() -> proc_macro2::TokenStream {
-    let mut derives = quote! {
-        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-    };
-
-    derives.extend(derive_serde());
-
-    derives
-}
-
-#[cfg(feature = "serde")]
-fn derive_serde() -> proc_macro2::TokenStream {
     quote! {
-        #[derive(serde::Deserialize, serde::Serialize)]
+        #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
     }
-}
-
-#[cfg(not(feature = "serde"))]
-fn derive_serde() -> proc_macro2::TokenStream {
-    quote! {}
 }

--- a/tests/name.rs
+++ b/tests/name.rs
@@ -5,10 +5,10 @@ use typed_fields::name;
 
 name!(
     /// A doc comment for the test name
+    #[derive(serde::Deserialize, serde::Serialize)]
     TestName
 );
 
-#[cfg(feature = "serde")]
 #[test]
 fn deserialize_returns_name() {
     let json = r#""test""#;
@@ -60,7 +60,6 @@ fn implements_unpin() {
     assert_unpin::<TestName>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
 fn serialize_returns_json() {
     let name = TestName::new("test");

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -5,6 +5,7 @@ use typed_fields::number;
 
 number!(
     /// A doc comment for the test id
+    #[derive(serde::Deserialize, serde::Serialize)]
     TestId
 );
 
@@ -13,7 +14,6 @@ number!(
     TestU64, u64
 );
 
-#[cfg(feature = "serde")]
 #[test]
 fn deserialize_returns_number() {
     let json = "42";
@@ -66,7 +66,6 @@ fn implements_unpin() {
     assert_unpin::<TestId>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
 fn serialize_returns_json() {
     let id = TestId::new(42);

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -7,10 +7,10 @@ use typed_fields::path;
 
 path!(
     /// A doc comment for the test path
+    #[derive(serde::Deserialize, serde::Serialize)]
     TestPath
 );
 
-#[cfg(feature = "serde")]
 #[test]
 fn deserialize_returns_path() {
     let json = r#""test""#;
@@ -62,7 +62,6 @@ fn implements_unpin() {
     assert_unpin::<TestPath>();
 }
 
-#[cfg(feature = "serde")]
 #[test]
 fn serialize_returns_json() {
     let name: TestPath = "test".into();

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -1,7 +1,17 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
-#[cfg(all(feature = "secret", feature = "serde"))]
+#[cfg(feature = "secret")]
+use typed_fields::secret;
+
+#[cfg(feature = "secret")]
+secret!(
+    /// A doc comment for the test secret
+    #[derive(serde::Deserialize)]
+    TestSecret
+);
+
+#[cfg(feature = "secret")]
 #[test]
 fn deserialize_returns_secret() {
     let json = r#""test""#;
@@ -18,15 +28,6 @@ fn display_returns_redacted_value() {
 
     assert_eq!("[REDACTED]", secret.to_string());
 }
-
-#[cfg(feature = "secret")]
-use typed_fields::secret;
-
-#[cfg(feature = "secret")]
-secret!(
-    /// A doc comment for the test secret
-    TestSecret
-);
 
 #[cfg(feature = "secret")]
 #[test]

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -1,7 +1,23 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
-#[cfg(all(feature = "serde", feature = "ulid"))]
+#[cfg(feature = "ulid")]
+use std::convert::TryInto;
+
+#[cfg(feature = "ulid")]
+use typed_fields::ulid;
+
+#[cfg(feature = "ulid")]
+use ulid::Ulid;
+
+#[cfg(feature = "ulid")]
+ulid!(
+    /// A doc comment for the test ULID
+    #[derive(serde::Deserialize, serde::Serialize)]
+    TestUlid
+);
+
+#[cfg(feature = "ulid")]
 #[test]
 fn deserialize_returns_ulid() {
     let json = r#""01ARZ3NDEKTSV4RRFFQ69G5FAV""#;
@@ -18,19 +34,6 @@ fn display_returns_inner_value() {
 
     assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
 }
-
-#[cfg(feature = "ulid")]
-use std::convert::TryInto;
-#[cfg(feature = "ulid")]
-use typed_fields::ulid;
-#[cfg(feature = "ulid")]
-use ulid::Ulid;
-
-#[cfg(feature = "ulid")]
-ulid!(
-    /// A doc comment for the test ULID
-    TestUlid
-);
 
 #[cfg(feature = "ulid")]
 #[test]
@@ -63,7 +66,7 @@ fn implements_unpin() {
     assert_unpin::<TestUlid>();
 }
 
-#[cfg(all(feature = "serde", feature = "ulid"))]
+#[cfg(feature = "ulid")]
 #[test]
 fn serialize_returns_json() {
     let ulid = TestUlid::new(Ulid::from_string("01ARZ3NDEKTSV4RRFFQ69G5FAV").unwrap());

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -1,7 +1,23 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
-#[cfg(all(feature = "serde", feature = "url"))]
+#[cfg(feature = "url")]
+use std::convert::TryInto;
+
+#[cfg(feature = "url")]
+use url::Url;
+
+#[cfg(feature = "url")]
+use typed_fields::url;
+
+#[cfg(feature = "url")]
+url!(
+    /// A doc comment for the test URL
+    #[derive(serde::Deserialize, serde::Serialize)]
+    TestUrl
+);
+
+#[cfg(feature = "url")]
 #[test]
 fn deserialize_returns_url() {
     let json = r#""postgres://localhost:5432/postgres""#;
@@ -18,21 +34,6 @@ fn display_returns_inner_value() {
 
     assert_eq!("https://example.com/", url.to_string());
 }
-
-#[cfg(feature = "url")]
-use std::convert::TryInto;
-
-#[cfg(feature = "url")]
-use url::Url;
-
-#[cfg(feature = "url")]
-use typed_fields::url;
-
-#[cfg(feature = "url")]
-url!(
-    /// A doc comment for the test URL
-    TestUrl
-);
 
 #[cfg(feature = "url")]
 #[test]
@@ -65,7 +66,7 @@ fn implements_unpin() {
     assert_unpin::<TestUrl>();
 }
 
-#[cfg(all(feature = "serde", feature = "url"))]
+#[cfg(feature = "url")]
 #[test]
 fn serialize_returns_json() {
     let url = TestUrl::new(Url::parse("https://example.com").unwrap());

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -1,7 +1,23 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
-#[cfg(all(feature = "serde", feature = "uuid"))]
+#[cfg(feature = "uuid")]
+use std::convert::TryInto;
+
+#[cfg(feature = "uuid")]
+use typed_fields::uuid;
+
+#[cfg(feature = "uuid")]
+use uuid::uuid as uuid_v4;
+
+#[cfg(feature = "uuid")]
+uuid!(
+    /// A doc comment for the test UUID
+    #[derive(serde::Deserialize, serde::Serialize)]
+    TestUuid
+);
+
+#[cfg(feature = "uuid")]
 #[test]
 fn deserialize_returns_uuid() {
     let json = r#""67e55044-10b1-426f-9247-bb680e5fe0c8""#;
@@ -18,20 +34,6 @@ fn display_returns_inner_value() {
 
     assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
 }
-
-#[cfg(feature = "uuid")]
-use std::convert::TryInto;
-
-#[cfg(feature = "uuid")]
-use typed_fields::uuid;
-#[cfg(feature = "uuid")]
-use uuid::uuid as uuid_v4;
-
-#[cfg(feature = "uuid")]
-uuid!(
-    /// A doc comment for the test UUID
-    TestUuid
-);
 
 #[cfg(feature = "uuid")]
 #[test]
@@ -64,7 +66,7 @@ fn implements_unpin() {
     assert_unpin::<TestUuid>();
 }
 
-#[cfg(all(feature = "serde", feature = "uuid"))]
+#[cfg(feature = "uuid")]
 #[test]
 fn serialize_returns_json() {
     let uuid = TestUuid::new(uuid_v4!("67e55044-10b1-426f-9247-bb680e5fe0c8"));


### PR DESCRIPTION
Cargo unifies features per package across the whole dependency graph, but a proc-macro crate emits its code into every crate that calls it. The `serde` feature therefore never stayed local to the crate that enabled it, and any crate sharing this instance received `serde::` paths whether or not it depended on serde.

This is the defect behind [jdno/labelflair#48](https://github.com/jdno/labelflair/pull/48). `labelflair` enables the feature; `clawless` uses this crate without it and has no serde dependency. While the two resolved to semver-incompatible versions Cargo kept them apart, but as soon as both reached 0.6.x they shared one instance and `clawless` stopped compiling:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `serde`
  --> clawless-0.4.0/src/context/current_working_directory.rs:4:1
```

I verified against a local checkout of that pull request, patched to this branch: `clawless` compiles and the whole labelflair suite passes.

## What replaces it

The derives move to the call site, which the macros already forward:

```rust
name!(
    #[derive(serde::Deserialize, serde::Serialize)]
    LabelName
);
```

Nothing is lost. This works for all seven macros, and `secret!` takes `#[derive(serde::Deserialize)]` alone, as before.

## The optional dependencies

`secrecy`, `ulid`, `url` and `uuid` move to dev-dependencies, and the four remaining features become plain markers that only decide which macros this crate exports. Those dependencies were never used by the macros. They existed to gate generated code and to propagate flags such as `uuid?/serde`, which has not reached a consumer since the second version of the feature resolver, so consumers already had to enable `uuid/serde` themselves. The tests declare them the way any consumer does.

This crate now depends on `proc-macro2`, `quote` and `syn`, and on nothing else.

## The guard

`just check-feature-unification` runs `cargo check --workspace --all-features`, which builds `tests/krate` (which enables no features) against a fully featured build of this crate. It fails on `main` today, with the error above, and passes here. CI builds its matrix from `just --list`, so this becomes a job automatically.

## Notes for review

- Includes a fix for a regression I introduced in #211: the reorder script treated `#[cfg(feature = "uuid")] use ...` lines as test blocks and sorted them among the tests, leaving the imports and the type declaration below the tests in `secret.rs`, `ulid.rs`, `url.rs` and `uuid.rs`. It compiled, so the checks stayed green. Declarations are back at the top. Happy to split this into its own pull request if you would rather review it separately.
- The feature powerset drops from 32 combinations to 16, and `just check-features` passes.
- `just pre-commit`, `just check-features` and `just check-feature-unification` all pass. I could not run `just check-unused-deps` locally because `cargo-udeps` is not installed here, so that one is left to CI.
- Breaking, like the SeaORM removal. Both belong in the same 0.7.0.