### PR TITLE
Assert the result of the conversion tests

### DIFF
--- a/tests/name.rs
+++ b/tests/name.rs
@@ -27,12 +27,16 @@ fn display_returns_inner_value() {
 
 #[test]
 fn from_str_returns_name() {
-    let _name: TestName = "test".into();
+    let name: TestName = "test".into();
+
+    assert_eq!("test", name.get());
 }
 
 #[test]
 fn from_string_returns_name() {
-    let _name: TestName = String::from("test").into();
+    let name: TestName = String::from("test").into();
+
+    assert_eq!("test", name.get());
 }
 
 #[test]

--- a/tests/number.rs
+++ b/tests/number.rs
@@ -32,7 +32,9 @@ fn display_returns_inner_value() {
 
 #[test]
 fn from_i64_returns_number() {
-    let _id: TestId = 42.into();
+    let id: TestId = 42.into();
+
+    assert_eq!(42, id.get());
 }
 
 #[test]

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -29,12 +29,16 @@ fn display_returns_inner_value() {
 
 #[test]
 fn from_str_returns_path() {
-    let _path: TestPath = "test".into();
+    let path: TestPath = "test".into();
+
+    assert_eq!(Path::new("test"), path.get());
 }
 
 #[test]
 fn from_string_returns_path() {
-    let _path: TestPath = String::from("test").into();
+    let path: TestPath = String::from("test").into();
+
+    assert_eq!(Path::new("test"), path.get());
 }
 
 #[test]

--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -40,13 +40,17 @@ fn expose_returns_secret() {
 #[cfg(feature = "secret")]
 #[test]
 fn from_str_returns_secret() {
-    let _secret: TestSecret = "test".into();
+    let secret: TestSecret = "test".into();
+
+    assert_eq!("test", secret.expose());
 }
 
 #[cfg(feature = "secret")]
 #[test]
 fn from_string_returns_secret() {
-    let _secret: TestSecret = "test".into();
+    let secret: TestSecret = "test".into();
+
+    assert_eq!("test", secret.expose());
 }
 
 #[cfg(feature = "secret")]

--- a/tests/ulid.rs
+++ b/tests/ulid.rs
@@ -79,7 +79,9 @@ fn serialize_returns_json() {
 #[cfg(feature = "ulid")]
 #[test]
 fn try_from_str_returns_ulid() {
-    let _ulid: TestUlid = "01ARZ3NDEKTSV4RRFFQ69G5FAV".try_into().unwrap();
+    let ulid: TestUlid = "01ARZ3NDEKTSV4RRFFQ69G5FAV".try_into().unwrap();
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
 }
 
 #[cfg(feature = "ulid")]
@@ -93,9 +95,11 @@ fn try_from_str_with_invalid_input_returns_error() {
 #[cfg(feature = "ulid")]
 #[test]
 fn try_from_string_returns_ulid() {
-    let _ulid: TestUlid = String::from("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+    let ulid: TestUlid = String::from("01ARZ3NDEKTSV4RRFFQ69G5FAV")
         .try_into()
         .unwrap();
+
+    assert_eq!("01ARZ3NDEKTSV4RRFFQ69G5FAV", ulid.to_string());
 }
 
 #[cfg(feature = "ulid")]

--- a/tests/url.rs
+++ b/tests/url.rs
@@ -79,7 +79,9 @@ fn serialize_returns_json() {
 #[cfg(feature = "url")]
 #[test]
 fn try_from_str_returns_url() {
-    let _url: TestUrl = "https://example.com/".try_into().unwrap();
+    let url: TestUrl = "https://example.com/".try_into().unwrap();
+
+    assert_eq!("https://example.com/", url.to_string());
 }
 
 #[cfg(feature = "url")]
@@ -93,9 +95,14 @@ fn try_from_str_with_invalid_input_returns_error() {
 #[cfg(feature = "url")]
 #[test]
 fn try_from_string_returns_url() {
-    let _url: TestUrl = String::from("postgres://user:password@locahost:5432/postgres")
+    let url: TestUrl = String::from("postgres://user:password@locahost:5432/postgres")
         .try_into()
         .unwrap();
+
+    assert_eq!(
+        "postgres://user:password@locahost:5432/postgres",
+        url.to_string()
+    );
 }
 
 #[cfg(feature = "url")]

--- a/tests/uuid.rs
+++ b/tests/uuid.rs
@@ -79,7 +79,9 @@ fn serialize_returns_json() {
 #[cfg(feature = "uuid")]
 #[test]
 fn try_from_str_returns_uuid() {
-    let _uuid: TestUuid = "67e55044-10b1-426f-9247-bb680e5fe0c8".try_into().unwrap();
+    let uuid: TestUuid = "67e55044-10b1-426f-9247-bb680e5fe0c8".try_into().unwrap();
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
 }
 
 #[cfg(feature = "uuid")]
@@ -93,9 +95,11 @@ fn try_from_str_with_invalid_input_returns_error() {
 #[cfg(feature = "uuid")]
 #[test]
 fn try_from_string_returns_uuid() {
-    let _uuid: TestUuid = String::from("67e55044-10b1-426f-9247-bb680e5fe0c8")
+    let uuid: TestUuid = String::from("67e55044-10b1-426f-9247-bb680e5fe0c8")
         .try_into()
         .unwrap();
+
+    assert_eq!("67e55044-10b1-426f-9247-bb680e5fe0c8", uuid.to_string());
 }
 
 #[cfg(feature = "uuid")]


### PR DESCRIPTION
Thirteen tests bound their result to a discarded variable and asserted nothing:

```rust
#[test]
fn from_str_returns_name() {
    let _name: TestName = "test".into();
}
```

That proves the conversion compiles and nothing else. A conversion that returned the wrong value passed, and the name promised a result the test never checked. `AGENTS.md` also asks that each test hold exactly one assertion, and these held none.

Each test now asserts the value it produces:

```rust
#[test]
fn from_str_returns_name() {
    let name: TestName = "test".into();

    assert_eq!("test", name.get());
}
```

## Notes for review

- Affects `From<&str>`, `From<String>`, `From<i64>`, `TryFrom<&str>` and `TryFrom<String>` across all seven test files.
- Verified the assertions actually fire, by changing an expected value and confirming the tests fail. They did not fail before this change.
- The duplicate conversion in `tests/secret.rs`, where `from_string_returns_secret` converts from a `&str`, is left alone here and fixed separately.

`just pre-commit` passes.