### PR TITLE
Convert from a String in the secret test

### DIFF
--- a/tests/secret.rs
+++ b/tests/secret.rs
@@ -48,7 +48,7 @@ fn from_str_returns_secret() {
 #[cfg(feature = "secret")]
 #[test]
 fn from_string_returns_secret() {
-    let secret: TestSecret = "test".into();
+    let secret: TestSecret = String::from("test").into();
 
     assert_eq!("test", secret.expose());
 }


### PR DESCRIPTION
Stacked on #213, which touches the same tests. GitHub retargets this at `main` once that one merges.

The test for `From<String>` on a secret converted from a `&str`:

```rust
#[test]
fn from_string_returns_secret() {
    let secret: TestSecret = "test".into();
}
```

So it duplicated `from_str_returns_secret` beside it, and the conversion it was named for went untested. It now converts from a `String`.

## Notes for review

- Verified by deleting `impl From<String>` from the `secret!` macro. The test now fails to compile, where before the change neither secret test noticed.
- Only `tests/secret.rs` changes.

`just pre-commit` passes.