### PR TITLE
Configure the files to publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,17 @@ repository = "https://github.com/jdno/typed-fields"
 # Rust edition 2024 requires Rust 1.85.0 or newer.
 rust-version = "1.85.0"
 
+# Ship only what a consumer of the crate needs. Everything else, such as the
+# development environment and the CI configuration, stays in the repository.
+include = [
+  "CHANGELOG.md",
+  "LICENSE-APACHE",
+  "LICENSE-MIT",
+  "README.md",
+  "src/**/*.rs",
+  "tests/*.rs",
+]
+
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
The package shipped every file that Git tracks, so crates.io and the [source browser on docs.rs](https://docs.rs/crate/typed-fields/0.6.1/source/) listed the Flox environment, the GitHub Actions workflows, the linter configuration and the justfile alongside the code. None of that helps somebody who depends on this crate, and it invites confusion about what the crate actually contains.

```toml
include = [
  "CHANGELOG.md",
  "LICENSE-APACHE",
  "LICENSE-MIT",
  "README.md",
  "src/**/*.rs",
  "tests/*.rs",
]
```

An include list is safer than an exclude list here, because a file added later has to be named before it ships rather than shipping by default. That is how the editor configuration added recently ended up in the package.

The published package goes from 50 files to 23, and from 15.9KiB to 17.7KiB compressed.

## Why the tests keep shipping

They already ship today, so dropping them would take away reference material rather than tidy anything up. They cost under 2KiB compressed, and since the tests were renamed and given real assertions they read as a summary of what each macro generates. They also answer the first question somebody upgrading to 0.7.0 will have, which is how to ask for the serde derives now that the feature is gone:

```rust
name!(
    /// A doc comment for the test name
    #[derive(serde::Deserialize, serde::Serialize)]
    TestName
);
```

Keeping them also keeps the `[[test]]` targets valid, so `cargo package` no longer warns seven times that it is dropping them.

## Notes for review

- The pattern is `tests/*.rs` rather than `tests/**/*.rs` on purpose. The recursive form takes `tests/krate/src/lib.rs` without its `Cargo.toml`, which would ship a broken fragment of the smoke test crate. Verified that the single star leaves `tests/krate` behind.
- Verified with `cargo package` and `cargo publish --dry-run`. Both succeed, and the verification build compiles the packaged crate.
- `CHANGELOG.md` ships deliberately, so that a vendored copy carries its history.
- No version bump. This is separate from the 0.7.0 release, which I will rebase on top.

`just pre-commit` passes.