### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-08-21
+
+### Removed
+
+- Remove support for SeaORM
+- Remove support for serde
+
+### Fixed
+
+- Fix the type name in the documentation of generated types
+
 ## [0.6.1] - 2026-03-29
 
 ### Fixed
@@ -99,6 +110,7 @@ and this project adheres to
 - Optionally derive serde traits
 - Create `secret!` macro for fields with secrets
 
+[0.7.0]: https://github.com/jdno/typed-fields/releases/tag/v0.7.0
 [0.6.1]: https://github.com/jdno/typed-fields/releases/tag/v0.6.1
 [0.6.0]: https://github.com/jdno/typed-fields/releases/tag/v0.6.0
 [0.5.2]: https://github.com/jdno/typed-fields/releases/tag/v0.5.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "typed-fields"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [".", "tests/krate"]
 
 [package]
 name = "typed-fields"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 description = "A collection of macros that generate newtypes"


### PR DESCRIPTION
This release removes the `sea-orm` and `serde` features, which caused issues with Cargo's feature unification. serde's traits can be derived manually on the types that need them. The `sea-orm` feature has been removed with no replacement.