### PR TITLE
Add From conversions for PathBuf

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -70,6 +70,18 @@ pub fn path_impl(input: TokenStream) -> TokenStream {
                 #ident::new(path.to_path_buf())
             }
         }
+
+        impl From<std::path::PathBuf> for #ident {
+            fn from(path: std::path::PathBuf) -> #ident {
+                #ident::new(path)
+            }
+        }
+
+        impl From<&std::path::PathBuf> for #ident {
+            fn from(path: &std::path::PathBuf) -> #ident {
+                #ident::new(path.clone())
+            }
+        }
     };
 
     newtype.into()

--- a/tests/path.rs
+++ b/tests/path.rs
@@ -1,7 +1,7 @@
 // TODO: Debug this warning, fix its cause, and remove this directive.
 #![allow(non_local_definitions)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use typed_fields::path;
 
@@ -25,6 +25,20 @@ fn display_returns_inner_value() {
     let path = TestPath::new("test".into());
 
     assert_eq!("test", path.to_string());
+}
+
+#[test]
+fn from_path_buf_returns_path() {
+    let path: TestPath = PathBuf::from("test").into();
+
+    assert_eq!(Path::new("test"), path.get());
+}
+
+#[test]
+fn from_ref_path_buf_returns_path() {
+    let path: TestPath = (&PathBuf::from("test")).into();
+
+    assert_eq!(Path::new("test"), path.get());
 }
 
 #[test]


### PR DESCRIPTION
The `path!` macro only implemented `From<&Path>`, plus the string conversions. It now also converts from `PathBuf` and `&PathBuf` by value, so callers can create a newtype from any common path type.

`From<Path>` is not implemented because `Path` is unsized and `From<T>` requires `T: Sized`, so an owned `Path` cannot be passed by value.